### PR TITLE
Rename src/ to agents/ and include directory in repo

### DIFF
--- a/.claude/skills/add-action/SKILL.md
+++ b/.claude/skills/add-action/SKILL.md
@@ -29,7 +29,7 @@ If the user requests an action **not in the catalog**, refuse and tell them:
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    If multiple agents found, ask which one. NEVER hardcode an agent name.
 
@@ -54,7 +54,7 @@ If the user requests an action **not in the catalog**, refuse and tell them:
 6. **Read `settings.mcs.yml`** to extract the `schemaName` (e.g., `copilots_header_e1ca2`). This is needed for the connection reference.
 
 7. **Check if the connector already exists** in `connectionreferences.mcs.yml`:
-   - Read `src/<agent-dir>/connectionreferences.mcs.yml`
+   - Read `agents/<agent-dir>/connectionreferences.mcs.yml`
    - Search for the connector's API name (e.g., `shared_teams`) in the `connectorId` values
    - If found: **reuse** the existing `connectionReferenceLogicalName`
    - If NOT found: **generate a new one** (see Connection Reference Generation below)
@@ -69,7 +69,7 @@ If the user requests an action **not in the catalog**, refuse and tell them:
 
 9. **Save the action file** to:
    ```
-   src/<agent-dir>/actions/<ConnectorName>-<TitleName>.mcs.yml
+   agents/<agent-dir>/actions/<ConnectorName>-<TitleName>.mcs.yml
    ```
    - `<ConnectorName>`: connector name in PascalCase (e.g., `MicrosoftTeams`, `Outlook`)
    - `<TitleName>`: modelDisplayName with spaces removed and first letter capitalized (e.g., `Postmessageinachatorchannel`)

--- a/.claude/skills/add-child-agent/SKILL.md
+++ b/.claude/skills/add-child-agent/SKILL.md
@@ -12,7 +12,7 @@ Create a new child agent (AgentDialog) that the parent agent's orchestrator can 
 
 1. **Auto-discover the parent agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    Use the top-level agent (not one inside an `agents/` subdirectory). NEVER hardcode an agent name.
 
@@ -30,7 +30,7 @@ Create a new child agent (AgentDialog) that the parent agent's orchestrator can 
 
 4. **Create the child agent directory** (Phase 1 — plain agent only, NO knowledge):
    ```
-   src/<parent-agent>/agents/<ChildAgentName>/
+   agents/<parent-agent>/agents/<ChildAgentName>/
    └── agent.mcs.yml
    ```
 

--- a/.claude/skills/add-generative-answers/SKILL.md
+++ b/.claude/skills/add-generative-answers/SKILL.md
@@ -22,7 +22,7 @@ If the user just wants the agent to answer questions from its knowledge, adding 
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    NEVER hardcode an agent name.
 
@@ -64,7 +64,7 @@ If the user just wants the agent to answer questions from its knowledge, adding 
 When using `knowledgeSources` to restrict the search to specific sources:
 
 1. The knowledge source **must already exist** in the agent (add it first with `/add-knowledge`)
-2. Find the knowledge source filename in `src/<agent-name>/knowledge/`
+2. Find the knowledge source filename in `agents/<agent-name>/knowledge/`
 3. Reference it **without the `.mcs.yml` extension**
 
 Example: if the file is `cre3c_agent.topic.MyDocs_abc123.mcs.yml`, the reference is:

--- a/.claude/skills/add-global-variable/SKILL.md
+++ b/.claude/skills/add-global-variable/SKILL.md
@@ -12,13 +12,13 @@ Create a global variable that persists across all topics within a conversation.
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    Use the top-level agent. NEVER hardcode an agent name.
 
 2. **Read `settings.mcs.yml`** to get the `schemaName` prefix:
    ```
-   Read: src/<agent-dir>/settings.mcs.yml
+   Read: agents/<agent-dir>/settings.mcs.yml
    ```
    Extract the root-level `schemaName` value (e.g., `copilots_header_cre3c_fullagent`).
 
@@ -28,7 +28,7 @@ Create a global variable that persists across all topics within a conversation.
    - Whether the AI orchestrator should be aware of it (`aIVisibility`)
    - Default value (if any)
 
-4. **Create the variable file** at `src/<agent-dir>/variables/<VariableName>.mcs.yml`:
+4. **Create the variable file** at `agents/<agent-dir>/variables/<VariableName>.mcs.yml`:
 
 ```yaml
 # Name: <Human-readable Name>

--- a/.claude/skills/add-knowledge/SKILL.md
+++ b/.claude/skills/add-knowledge/SKILL.md
@@ -12,7 +12,7 @@ Add a knowledge source to the agent. Supports **Public Website**, **SharePoint**
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    NEVER hardcode an agent name.
 
@@ -67,7 +67,7 @@ Add a knowledge source to the agent. Supports **Public Website**, **SharePoint**
 
 7. **Always include `# Name:` and a description comment** at the top. These are important for identifying the knowledge source.
 
-8. **Save** to `src/<agent-name>/knowledge/<descriptive-name>.knowledge.mcs.yml`
+8. **Save** to `agents/<agent-name>/knowledge/<descriptive-name>.knowledge.mcs.yml`
 
 ## Custom API via OnKnowledgeRequested (YAML-only)
 

--- a/.claude/skills/add-node/SKILL.md
+++ b/.claude/skills/add-node/SKILL.md
@@ -16,7 +16,7 @@ In Copilot Studio, the elements inside a topic's `actions` array are **nodes** (
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    NEVER hardcode an agent name.
 

--- a/.claude/skills/best-practices/jit-glossary.md
+++ b/.claude/skills/best-practices/jit-glossary.md
@@ -51,7 +51,7 @@ A starter template is available at `templates/knowledge/glossary.csv`.
 
 ## Step 2 — Create the Knowledge Source
 
-Create a file in `src/<AGENT-NAME>/knowledge/` for the glossary source. Example: `glossary.knowledge.mcs.yml`.
+Create a file in `agents/<AGENT-NAME>/knowledge/` for the glossary source. Example: `glossary.knowledge.mcs.yml`.
 
 ```yaml
 # Name: Customer Glossary
@@ -70,7 +70,7 @@ source:
 
 ## Step 3 — Create the Global Variable
 
-Create `src/<AGENT-NAME>/variables/Glossary.mcs.yml`. Read `settings.mcs.yml` first to get the agent's `schemaName` prefix.
+Create `agents/<AGENT-NAME>/variables/Glossary.mcs.yml`. Read `settings.mcs.yml` first to get the agent's `schemaName` prefix.
 
 ```yaml
 # Name: Glossary
@@ -93,7 +93,7 @@ Or use the `add-global-variable` skill to generate this file.
 
 > **If you are also loading user context**, use the combined template at `templates/topics/conversation-init.topic.mcs.yml` instead. It merges both patterns into a single OnActivity topic with one `=IsBlank(Global.UserCountry)` condition.
 
-Create `src/<AGENT-NAME>/topics/conversation-init.topic.mcs.yml`:
+Create `agents/<AGENT-NAME>/topics/conversation-init.topic.mcs.yml`:
 
 ```yaml
 kind: AdaptiveDialog
@@ -128,7 +128,7 @@ beginDialog:
 
 ## Step 5 — Update Agent Instructions
 
-In `src/<AGENT-NAME>/agents/agent.mcs.yml` or `settings.mcs.yml`, add a glossary usage section to the agent's instructions:
+In `agents/<AGENT-NAME>/agents/agent.mcs.yml` or `settings.mcs.yml`, add a glossary usage section to the agent's instructions:
 
 ```yaml
 instructions: |
@@ -149,7 +149,7 @@ Before testing:
 - [ ] `triggerCondition: =false` is on the knowledge source
 - [ ] The knowledge source reference in `SearchAndSummarizeContent` matches the exact `.mcs.yml` filename
 - [ ] All `REPLACE` IDs are replaced with unique generated IDs
-- [ ] `Global.Glossary` variable exists at `src/<AGENT-NAME>/variables/Glossary.mcs.yml` with `schemaName` matching the agent prefix
+- [ ] `Global.Glossary` variable exists at `agents/<AGENT-NAME>/variables/Glossary.mcs.yml` with `schemaName` matching the agent prefix
 - [ ] Agent instructions reference `{Global.Glossary}` with clear usage rules
 
 ## Testing

--- a/.claude/skills/best-practices/jit-user-context.md
+++ b/.claude/skills/best-practices/jit-user-context.md
@@ -27,12 +27,12 @@ Agent instructions reference {Global.UserCountry} ← single injection, context-
 
 Before authoring the YAML:
 1. **The M365 Users connector must be configured in Copilot Studio**. Go to the agent's Settings → Connections and add a connection for "Microsoft 365 Users".
-2. **Verify the connection reference name**. Read `src/<AGENT-NAME>/connectionreferences.mcs.yml` and note the exact `logicalName` for the M365 Users connector — you will use this as the `connectionReference` value. It is typically `shared_office365users` but may differ.
+2. **Verify the connection reference name**. Read `agents/<AGENT-NAME>/connectionreferences.mcs.yml` and note the exact `logicalName` for the M365 Users connector — you will use this as the `connectionReference` value. It is typically `shared_office365users` but may differ.
 3. The user's M365 profile must have the `country` field populated in Azure AD. If it is blank, the pattern falls back to `Global.UserCountry = ""` — see the fallback handling in Step 2.
 
 ## Step 1 — Create the Global Variable
 
-Create `src/<AGENT-NAME>/variables/UserCountry.mcs.yml`. Read `settings.mcs.yml` first to get the `schemaName` prefix.
+Create `agents/<AGENT-NAME>/variables/UserCountry.mcs.yml`. Read `settings.mcs.yml` first to get the `schemaName` prefix.
 
 ```yaml
 # Name: UserCountry
@@ -54,7 +54,7 @@ defaultValue: DEFAULT
 
 > **If you are also loading a glossary**, use the combined template at `templates/topics/conversation-init.topic.mcs.yml` instead. It merges both patterns into a single OnActivity topic with one `=IsBlank(Global.UserCountry)` condition.
 
-Create `src/<AGENT-NAME>/topics/conversation-init.topic.mcs.yml`:
+Create `agents/<AGENT-NAME>/topics/conversation-init.topic.mcs.yml`:
 
 ```yaml
 kind: AdaptiveDialog
@@ -94,7 +94,7 @@ beginDialog:
 
 ## Step 3 — Update Agent Instructions
 
-In `src/<AGENT-NAME>/agents/agent.mcs.yml` or `settings.mcs.yml`:
+In `agents/<AGENT-NAME>/agents/agent.mcs.yml` or `settings.mcs.yml`:
 
 ```yaml
 instructions: |

--- a/.claude/skills/edit-agent/SKILL.md
+++ b/.claude/skills/edit-agent/SKILL.md
@@ -12,7 +12,7 @@ Modify agent metadata (`agent.mcs.yml`) or configuration (`settings.mcs.yml`).
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    NEVER hardcode an agent name. If multiple agents found, ask which one.
 

--- a/.claude/skills/edit-triggers/SKILL.md
+++ b/.claude/skills/edit-triggers/SKILL.md
@@ -12,13 +12,13 @@ Modify how a topic gets triggered: **trigger phrases** (`triggerQueries`) and **
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    NEVER hardcode an agent name.
 
 2. **Find the target topic**:
    ```
-   Glob: src/<agent-name>/topics/*.topic.mcs.yml
+   Glob: agents/<agent-name>/topics/*.topic.mcs.yml
    ```
    If `$ARGUMENTS` specifies a topic name, match it. Otherwise, list all topics and ask which one.
 

--- a/.claude/skills/list-topics/SKILL.md
+++ b/.claude/skills/list-topics/SKILL.md
@@ -11,14 +11,14 @@ List all topics in the current agent with their trigger types and details.
 
 1. **Auto-discover the agent directory** — find all agents via:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    - If multiple agents found, list them and ask which one to inspect.
    - NEVER hardcode an agent name or path.
 
 2. Find all topic files in the discovered agent directory:
    ```
-   Glob: src/<discovered-agent>/topics/*.topic.mcs.yml
+   Glob: agents/<discovered-agent>/topics/*.topic.mcs.yml
    ```
 
 3. For each topic file, read it and extract:

--- a/.claude/skills/new-topic/SKILL.md
+++ b/.claude/skills/new-topic/SKILL.md
@@ -12,7 +12,7 @@ Generate a new Copilot Studio topic YAML file based on user requirements.
 
 1. **Auto-discover the agent directory**:
    ```
-   Glob: src/**/agent.mcs.yml
+   Glob: agents/**/agent.mcs.yml
    ```
    If multiple agents found, ask which one. NEVER hardcode an agent name.
 
@@ -52,7 +52,7 @@ Generate a new Copilot Studio topic YAML file based on user requirements.
 
 6. **Check settings.mcs.yml** for `GenerativeActionsEnabled`. Read the agent's `settings.mcs.yml` to check.
 
-7. **Save** to `src/<agent-name>/topics/<topic-name>.topic.mcs.yml`
+7. **Save** to `agents/<agent-name>/topics/<topic-name>.topic.mcs.yml`
 
 8. **MANDATORY: Validate the generated file** after saving:
    ```bash

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -190,7 +190,7 @@ Works identically regardless of mode — only the data source differs.
 Mode-agnostic — works from analyzed failure data regardless of source.
 
 1. **For each failure, identify the relevant YAML file(s)**:
-   - Auto-discover the agent: `Glob: src/**/agent.mcs.yml`
+   - Auto-discover the agent: `Glob: agents/**/agent.mcs.yml`
    - Find the relevant topic by matching the test utterance against trigger phrases and model descriptions
    - Read the topic file to understand the current flow
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Copilot Studio Claude Code Project - Git Ignore
 
-# Agents clones
-src/
+# Agents clones (ignore contents, keep directory)
+agents/*/
 *.zip
 
 # Agent tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ project-root/
 │   ├── agents.json                         # Local agent registry (auto-discovered or manual)
 │   ├── settings.json                       # Test configuration (user fills in)
 │   └── test-results-*.csv                  # Downloaded test results
-└── src/AGENT-NAME/                         # YAML files representing the agent
+└── agents/AGENT-NAME/                         # YAML files representing the agent
     ├── topics/                             # Conversation topics
     ├── actions/                            # Connector-based actions
     ├── knowledge/                          # Knowledge sources
@@ -28,7 +28,7 @@ project-root/
     └── agents/                             # Child agents
 ```
 
-**Note**: The `src/AGENT-NAME/` directory is created when you clone your first agent from your environment. It doesn't exist until you clone a Copilot Studio agent. If the user does not know how to clone an agent, point them to the "Copilot Studio Extension inside VS Code".
+**Note**: Clone your Copilot Studio agents into the `agents/` directory using the VS Code Extension. The directory is included in the repo but its contents are gitignored (agent clones are user-specific).
 
 ## Schema Lookup (Critical)
 
@@ -66,7 +66,7 @@ The above ones are already used as examples with real parameter values, like "se
 
 ## Agent Discovery (Important)
 
-The agent name is dynamic — users clone their own agent. **NEVER hardcode an agent name or path.** Always auto-discover via `Glob: src/**/agent.mcs.yml`. If multiple agents found, ask which one.
+The agent name is dynamic — users clone their own agent. **NEVER hardcode an agent name or path.** Always auto-discover via `Glob: agents/**/agent.mcs.yml`. If multiple agents found, ask which one.
 
 ## Agent Registry (Shared Convention)
 
@@ -83,7 +83,7 @@ When a skill needs to connect to a published agent (e.g., `/chat-with-agent`, `/
     "agentIdentifier": "copilots_header_9b50c",
     "clientId": "user-provided-app-registration-id",
     "dataverseEndpoint": "https://org5d9d4b6b.crm.dynamics.com/",
-    "localPath": "src/Agent 7"
+    "localPath": "agents/Agent 7"
   }
 }
 ```
@@ -91,7 +91,7 @@ When a skill needs to connect to a published agent (e.g., `/chat-with-agent`, `/
 **Lookup convention** — when a skill needs connection info, follow these steps in order:
 
 1. **Check `tests/agents.json`** — if it exists and has a complete entry for the target agent, use it.
-2. **Auto-discover from VS Code extension clones** — glob for `**/.mcs/conn.json` (covers both `src/` subdirectories and the project root if Claude was initiated directly in a cloned agent folder). For each match:
+2. **Auto-discover from VS Code extension clones** — glob for `**/.mcs/conn.json` (covers both `agents/` subdirectories and the project root if Claude was initiated directly in a cloned agent folder). For each match:
    - Read `.mcs/conn.json` for `EnvironmentId`, `AccountInfo.TenantId`, and `DataverseEndpoint`
    - Read the sibling `settings.mcs.yml` (one level up from `.mcs/`) for `schemaName` (this is the `agentIdentifier`)
    - Read the sibling `agent.mcs.yml` for the display name

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Place your `bot.schema.yaml-authoring.json` in the `reference/` directory.
 
 ### 4. Clone your Copilot Studio agent
 
-Use the **Copilot Studio VS Code Extension** to clone your agent into the `src/` directory. This downloads your agent's YAML files (topics, actions, knowledge, settings).
+Use the **Copilot Studio VS Code Extension** to clone your agent into the `agents/` directory. This downloads your agent's YAML files (topics, actions, knowledge, settings).
 
 ### 5. Start Claude Code
 
@@ -44,7 +44,7 @@ Invoke any skill directly with `/<skill-name>`:
 /new-topic A FAQ topic that answers questions about our return policy
 /add-node SendActivity node to Greeting topic
 /edit-triggers Greeting
-/validate src/My Agent/topics/Greeting.mcs.yml
+/validate agents/My Agent/topics/Greeting.mcs.yml
 /list-topics
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,7 +56,7 @@ This file contains reference tables for Copilot Studio YAML authoring. For workf
 
 ## Connector Actions (TaskDialog)
 
-Connector actions (`kind: TaskDialog`) invoke external connector operations. They are stored in `src/<agent>/actions/` and require a connection reference in `connectionreferences.mcs.yml`.
+Connector actions (`kind: TaskDialog`) invoke external connector operations. They are stored in `agents/<agent>/actions/` and require a connection reference in `connectionreferences.mcs.yml`.
 
 **Use `/add-action` to create actions from the verified catalog.** The schema can describe the structural properties of `TaskDialog` and `InvokeConnectorTaskAction`, but the specific inputs and outputs for each connector operation are connector-specific — use only verified sample templates.
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -126,7 +126,7 @@ Follow these steps: https://github.com/microsoft/vscode-copilotstudio
 
 Clone the agent via the VS Code Copilot Studio Extension.
 
-The guideline is to put the agent folder into the `src/` directory with the unpacked YAML files.
+The guideline is to put the agent folder into the `agents/` directory with the unpacked YAML files.
 
 **Checkpoint 3:** Verify the clone was successful:
 
@@ -155,7 +155,7 @@ copilot-studio-dev/
 ├── scripts/
 │   └── schema-lookup.py
 ├── templates/
-└── src/
+└── agents/
     └── <your-agent-name>/
         ├── agent.mcs.yml           # Agent metadata
         ├── settings.mcs.yml        # Agent settings
@@ -241,7 +241,7 @@ Expected output: All available `kind` discriminator values from your schema.
 ### Step 5.5: Test Validation
 
 ```bash
-python scripts/schema-lookup.py validate src/<your-agent-name>/topics/Greeting.mcs.yml
+python scripts/schema-lookup.py validate agents/<your-agent-name>/topics/Greeting.mcs.yml
 ```
 
 Expected output: A `[PASS]`/`[WARN]`/`[FAIL]` validation report.
@@ -295,12 +295,12 @@ It should ask the user which product they're interested in and then provide info
 Claude should:
 1. Use the schema lookup to verify the correct structure
 2. Generate a valid YAML file with unique IDs
-3. Save it to the appropriate location in `src/<your-agent-name>/topics/`
+3. Save it to the appropriate location in `agents/<your-agent-name>/topics/`
 
 ### Step 7.2: Validate the Generated Topic
 
 ```
-/validate src/<your-agent-name>/topics/ProductInformation.topic.mcs.yml
+/validate agents/<your-agent-name>/topics/ProductInformation.topic.mcs.yml
 ```
 
 Claude should validate the generated YAML against the schema.
@@ -409,7 +409,7 @@ Use this checklist to verify your setup is complete:
 - [ ] Python dependencies installed (`pip install -r requirements.txt`)
 - [ ] Schema lookup script tested and working
 - [ ] VS Code Copilot Studio Extension installed
-- [ ] Existing agent cloned to `src/`
+- [ ] Existing agent cloned to `agents/`
 - [ ] Claude Code initialized and reading `CLAUDE.md`
 - [ ] Skills tested and working
 - [ ] YAML generation tested

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,12 @@
+# Agents Directory
+
+Clone your Copilot Studio agents here using the **Copilot Studio VS Code Extension**.
+
+Each subdirectory is a cloned agent with its YAML files (topics, actions, knowledge, variables, settings). Agent contents are gitignored since they are user-specific.
+
+## How to clone an agent
+
+1. Install the [Copilot Studio Extension](https://marketplace.visualstudio.com/items?itemName=microsoft-IsvExpTools.microsoft-copilot-studio) in VS Code
+2. Sign in and select your environment
+3. Clone your agent into this `agents/` directory
+4. The extension creates a subfolder like `agents/My Agent/`

--- a/tests/agents-example.json
+++ b/tests/agents-example.json
@@ -5,6 +5,6 @@
     "agentIdentifier": "YOUR_AGENT_SCHEMA_NAME",
     "clientId": "YOUR_CLIENT_ID",
     "dataverseEndpoint": "https://YOUR_ORG.crm.dynamics.com/",
-    "localPath": "src/YOUR_AGENT_FOLDER"
+    "localPath": "agents/YOUR_AGENT_FOLDER"
   }
 }


### PR DESCRIPTION
## Summary

- Rename all `src/` references to `agents/` across 19 files (skills, docs, templates)
- Add `agents/README.md` explaining the directory purpose and how to clone agents
- Gitignore `agents/*/` (contents) instead of `agents/` (directory) so it exists when cloning the repo
- The `agents/` name clearly communicates purpose vs `src/` which implies source code

## Migration for existing users

If you already have agents cloned in `src/`, just move them:
```bash
mv src/* agents/
```
And update `tests/agents.json` if you have one (change `localPath` from `src/...` to `agents/...`).

The `src/` directory was always gitignored, so no tracked files are affected.

Closes #12

## Test plan

- [x] All `src/` references replaced (verified with grep — zero remaining)
- [x] `agents/README.md` tracked in git
- [x] Agent clone contents (`agents/*/`) properly gitignored
- [x] Existing cloned agent works from new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)