### PR TITLE
Hide all skills from direct user invocation

### DIFF
--- a/skills/add-action/SKILL.md
+++ b/skills/add-action/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Add a connector-based action (TaskDialog) to a Copilot Studio agent. Use when the user asks to add a connector action like sending a Teams message, creating an Outlook event, or other connector operations.
 argument-hint: <action description, e.g. "post a Teams message">
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Edit, Glob

--- a/skills/add-adaptive-card/SKILL.md
+++ b/skills/add-adaptive-card/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Generate and insert an Adaptive Card into a Copilot Studio topic using AdaptiveCardPrompt. Use when the user asks to add an adaptive card, rich card, form card, info card, confirmation card, or interactive card to a topic.
 argument-hint: <card-type> in <topic-name>
 allowed-tools: Bash(python scripts/schema-lookup.py *), Read, Write, Edit, Glob

--- a/skills/add-child-agent/SKILL.md
+++ b/skills/add-child-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Add or configure a child agent (AgentDialog) for Copilot Studio. Use when the user asks to create a sub-agent, child agent, or specialist agent.
 argument-hint: <child agent description>
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Glob

--- a/skills/add-generative-answers/SKILL.md
+++ b/skills/add-generative-answers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Add generative answer nodes (SearchAndSummarizeContent or AnswerQuestionWithAI) to a Copilot Studio topic. Use this instead of /add-node when the user asks to add grounded answers, knowledge search, generative answers, or AI-powered responses — these nodes require specific patterns (ConditionGroup follow-up, knowledge source references, autoSend, responseCaptureType) that /add-node does not cover.
 argument-hint: <topic-name or "new">
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Edit, Glob

--- a/skills/add-global-variable/SKILL.md
+++ b/skills/add-global-variable/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Add a global variable to a Copilot Studio agent. Use when the user needs a variable that persists across topics in the same conversation and can optionally be visible to the AI orchestrator.
 argument-hint: <variable name and purpose>
 allowed-tools: Read, Write, Glob, Grep

--- a/skills/add-knowledge/SKILL.md
+++ b/skills/add-knowledge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Add a knowledge source (public website or SharePoint) to a Copilot Studio agent. Use when the user asks to add a knowledge source, documentation URL, website, or SharePoint site for the agent to search.
 argument-hint: <url>
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Glob

--- a/skills/add-node/SKILL.md
+++ b/skills/add-node/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Add or modify a node in an existing Copilot Studio topic. Use when the user asks to add a question, message, condition, variable, or other node to a topic. Do NOT use this for generative answers or knowledge search — use /add-generative-answers instead.
 argument-hint: <node-type> to <topic-name>
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Edit, Glob

--- a/skills/best-practices/SKILL.md
+++ b/skills/best-practices/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 name: best-practices
 description: "Best practices for Copilot Studio agents. Covers JIT glossary loading (customer acronyms, terminology), JIT user context provisioning (M365 profile, country, department), and the shared OnActivity initialization pattern. USE FOR: glossary, acronyms, user context, user profile, country-aware answers, JIT initialization, OnActivity provisioning, conversation-init, personalized knowledge. DO NOT USE FOR: general knowledge sources (use add-knowledge), topic creation (use new-topic)."
 context: fork

--- a/skills/chat-with-agent/SKILL.md
+++ b/skills/chat-with-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Send a message to a published Copilot Studio agent and get its full response. Use when the user asks to test a specific utterance, check how the agent responds, verify a topic was fixed, or do a quick point-test after making YAML changes. Also useful for multi-turn conversation testing.
 argument-hint: <utterance to send>
 allowed-tools: Bash(node *chat-with-agent.bundle.js *), Read, Glob, Grep

--- a/skills/edit-agent/SKILL.md
+++ b/skills/edit-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Edit Copilot Studio agent settings, instructions, or configuration. Use when the user asks to change agent instructions, display name, conversation starters, AI settings, or generative actions toggle.
 argument-hint: <what to change>
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Edit, Glob

--- a/skills/edit-triggers/SKILL.md
+++ b/skills/edit-triggers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Modify topic triggers — trigger phrases and model description. Use when the user asks to add, remove, or change trigger phrases, or edit a topic's model description.
 argument-hint: <topic-name>
 allowed-tools: Read, Edit, Glob

--- a/skills/list-kinds/SKILL.md
+++ b/skills/list-kinds/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: List all available kind discriminator values from the Copilot Studio YAML schema. Use when the user asks what kinds/types are available.
 argument-hint: <optional-filter-keyword>
 allowed-tools: Bash(node *schema-lookup.bundle.js *)

--- a/skills/list-topics/SKILL.md
+++ b/skills/list-topics/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: List all topics in the Copilot Studio agent with their trigger types, phrases, and action counts. Use when the user wants to see what topics exist.
 allowed-tools: Read, Glob, Grep
 ---

--- a/skills/lookup-schema/SKILL.md
+++ b/skills/lookup-schema/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Look up Copilot Studio YAML schema definitions. Use when the user asks about schema structure, element properties, or how to use a specific YAML kind.
 argument-hint: <definition-name>
 allowed-tools: Bash(node *schema-lookup.bundle.js *)

--- a/skills/new-topic/SKILL.md
+++ b/skills/new-topic/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Create a new Copilot Studio topic YAML file. Use when the user asks to create a new topic, conversation flow, or dialog for their agent.
 argument-hint: <topic description>
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Glob

--- a/skills/run-tests/SKILL.md
+++ b/skills/run-tests/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Run or analyze tests for a published Copilot Studio agent. Two modes — run a batch test suite via the Copilot Studio Kit (Dataverse API), or import and analyze results from Copilot Studio's built-in evaluations. Not for sending a single test message — use /chat-with-agent for that instead.
 allowed-tools: Bash(node *run-tests.js *), Bash(npm install *), Read, Write, Glob, Grep, Edit
 context: fork

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,4 +1,5 @@
 ---
+user-invocable: false
 description: Validate a Copilot Studio YAML file against the schema and best practices. Use when the user asks to check, validate, or verify a YAML file.
 argument-hint: <path-to-yaml-file>
 allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Glob


### PR DESCRIPTION
## Summary

- Add `user-invocable: false` to all 17 skills that were previously directly accessible via `/copilot-studio:skillname`
- Users now interact exclusively through sub-agents (`@copilot-studio:author`, `@copilot-studio:test`, `@copilot-studio:troubleshoot`), which invoke skills internally
- The two shared skills (`_project-context`, `_reference`) already had this set

## Test plan

- [ ] Verify `/copilot-studio:` skills no longer appear in the `/` autocomplete menu
- [ ] Verify sub-agents can still invoke skills (e.g., `@copilot-studio:author` can use `new-topic`)
- [ ] Verify `@copilot-studio:test` routes to `chat-with-agent` and `run-tests` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)