### PR TITLE
Clarify crawl depth limitations in knowledge source documentation

### DIFF
--- a/skills/add-knowledge/SKILL.md
+++ b/skills/add-knowledge/SKILL.md
@@ -58,6 +58,8 @@ Add a knowledge source to the agent. Supports **Public Website**, **SharePoint**
      site: https://www.example.com
    ```
 
+   > **Crawl depth:** The URL must be at most 2 levels deep — Copilot Studio will reject URLs with more than 2 path segments (e.g. `https://docs.example.com/en-us/products/` is valid, `https://example.com/en-us/products/categories/one` is not). If the user provides a URL that is too deep, ask them to use a shallower root URL.
+
    **SharePoint:**
    ```yaml
    # Name: <Name>

--- a/skills/add-knowledge/knowledge-guide.md
+++ b/skills/add-knowledge/knowledge-guide.md
@@ -94,6 +94,7 @@ Use the template at `templates/knowledge/graph-connector.knowledge.mcs.yml`.
 - The site must be publicly crawlable — no login required
 - Avoid URLs that return dynamic content or require JavaScript rendering
 - Subdomains are treated as separate sources; add them individually if needed
+- **Crawl depth:** limit the crawl to a maximum of 2 levels deep. This prevents the error message "The website can't be more than two levels deep". (e.g. `https://docs.example.com/en-us/products/` not `https://example.com/en-us/products/categories/one`)
 
 **SharePoint:**
 - Use the deepest folder path that covers the needed documents (avoid sharing the root site)

--- a/templates/knowledge/public-website.knowledge.mcs.yml
+++ b/templates/knowledge/public-website.knowledge.mcs.yml
@@ -3,4 +3,5 @@
 kind: KnowledgeSourceConfiguration
 source:
   kind: PublicSiteSearchSource
+  # Replace with your public website URL. The crawl limit is set to a maximum of 2 levels deep
   site: https://example.com/docs


### PR DESCRIPTION
# Issue

<img width="865" height="429" alt="image" src="https://github.com/user-attachments/assets/8636a249-1af0-4aba-a841-d0b7930d026f" />

This pull request clarifies the crawl depth requirements for adding public website knowledge sources, ensuring users avoid errors related to overly deep URLs. The updates provide explicit guidance in documentation and configuration templates.

**Documentation improvements:**

* Added a note in `skills/add-knowledge/SKILL.md` explaining that Copilot Studio will reject URLs with more than 2 path segments, and instructing users to select shallower root URLs if needed.
* Updated `skills/add-knowledge/knowledge-guide.md` to highlight the 2-level crawl depth limit and provide examples to prevent common errors.

**Configuration template update:**

* Added a comment to `templates/knowledge/public-website.knowledge.mcs.yml` specifying the crawl limit of 2 levels deep for public website sources.