### PR TITLE
Add DirectLine v3 chat skill for testing bots

### DIFF
--- a/agents/test.md
+++ b/agents/test.md
@@ -19,12 +19,14 @@ When the user asks to "test the agent" without specifying how, **present both op
 |----------|-------|-------------|----------|
 | **Point-test** | `/copilot-studio:chat-with-agent` | Sends a single utterance directly to the published agent via the **Copilot Studio Client SDK** and returns the full response. Best for quick checks and multi-turn conversations. | App Registration with `CopilotStudio.Copilots.Invoke` permission |
 | **Batch test suite** | `/copilot-studio:run-tests` (Kit mode) | Runs pre-defined test sets with expected responses via the **Dataverse API** using the [Power CAT Copilot Studio Kit](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit) (open-source, by the Power CAT team). Produces pass/fail results with latencies. | The Copilot Studio Kit installed in the environment + App Registration with Dataverse permissions |
+| **DirectLine chat** | `/copilot-studio:directline-chat` | Sends a single utterance via the **DirectLine v3 REST API** (pure HTTP polling). Works with any bot that has DirectLine enabled. Supports OAuth/sign-in card flows. | DirectLine secret (Azure Bot Service) or Copilot Studio token endpoint URL |
 | **Analyze evaluations** | `/copilot-studio:run-tests` (eval mode) | User runs evaluations in the Copilot Studio UI, exports results as CSV, and shares the file for analysis and fix proposals. | Agent published + evaluations run in Copilot Studio UI |
 
 **When to invoke directly (without asking):**
 - User provides a specific utterance (e.g., "test 'what's the PTO policy'") → `/copilot-studio:chat-with-agent`
 - User says "run the test suite" or "run tests" → `/copilot-studio:run-tests`
 - User shares a CSV or says "analyze these results" / "here are my eval results" → `/copilot-studio:run-tests`
+- User provides a DirectLine secret or token endpoint URL → `/copilot-studio:directline-chat`
 - User says "validate the YAML" → `/copilot-studio:validate`
 
 ## MANDATORY: Use skills — NEVER do things manually
@@ -35,6 +37,7 @@ You are FORBIDDEN from running test scripts or validation manually when a skill 
 
 - **`/chat-with-agent`**: Connection details are auto-discovered from the VS Code extension's `.mcs/conn.json` and `settings.mcs.yml`. The only value the user must provide is their **App Registration Client ID**.
 - **`/run-tests`**: Requires a separate `tests/settings.json` with the Dataverse environment URL, tenant ID, client ID, agent configuration ID, and test set ID (the skill walks through setup).
+- **`/directline-chat`**: Requires either a Copilot Studio token endpoint URL or a DirectLine secret. No app registration needed for token endpoint mode.
 
 ## Critical reminder
 Only **published** agents are reachable by tests. Pushing creates a draft.

--- a/scripts/directline-chat.bundle.js
+++ b/scripts/directline-chat.bundle.js
@@ -1,0 +1,326 @@
+// src/directline-chat.js
+var readline = require("readline");
+function log(msg) {
+  process.stderr.write(msg + "\n");
+}
+function die(msg) {
+  process.stdout.write(JSON.stringify({ status: "error", error: msg }) + "\n");
+  process.exit(1);
+}
+var sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {
+    utterance: null,
+    conversationId: null,
+    tokenEndpoint: null,
+    directlineSecret: null,
+    directlineDomain: null,
+    directlineToken: null,
+    watermark: null
+  };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--token-endpoint":
+        parsed.tokenEndpoint = args[++i];
+        break;
+      case "--directline-secret":
+        parsed.directlineSecret = args[++i];
+        break;
+      case "--directline-domain":
+        parsed.directlineDomain = args[++i];
+        break;
+      case "--directline-token":
+        parsed.directlineToken = args[++i];
+        break;
+      case "--watermark":
+        parsed.watermark = args[++i];
+        break;
+      case "--conversation-id":
+        parsed.conversationId = args[++i];
+        break;
+      default:
+        if (!args[i].startsWith("--")) {
+          parsed.utterance = args[i];
+        }
+        break;
+    }
+  }
+  if (!parsed.utterance) die("Missing utterance argument.");
+  if (!parsed.tokenEndpoint && !parsed.directlineSecret) {
+    die("Missing connection: provide --token-endpoint or --directline-secret.");
+  }
+  if (parsed.tokenEndpoint && parsed.directlineSecret) {
+    die("Provide only one of --token-endpoint or --directline-secret, not both.");
+  }
+  return parsed;
+}
+async function httpGet(url, headers) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    die(`HTTP ${res.status} from GET ${url}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+async function httpPost(url, headers, body) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    die(`HTTP ${res.status} from POST ${url}: ${text.slice(0, 200)}`);
+  }
+  return res.json();
+}
+async function fetchToken(tokenEndpointUrl) {
+  log("Fetching DirectLine token from token endpoint...");
+  const data = await httpGet(tokenEndpointUrl, {});
+  if (!data.token) die("Token endpoint did not return a token.");
+  return data.token;
+}
+async function getRegionalDomain(tokenEndpointUrl) {
+  try {
+    const parsed = new URL(tokenEndpointUrl);
+    const settingsUrl = parsed.origin + "/powervirtualagents/regionalchannelsettings?api-version=2022-03-01-preview";
+    log("Fetching regional DirectLine domain...");
+    const data = await httpGet(settingsUrl, {});
+    const domain = data.channelUrlsById?.directline?.replace(/\/+$/, "");
+    if (domain) {
+      log(`Regional domain: ${domain}`);
+      return domain;
+    }
+  } catch (e) {
+    log(`Warning: Could not fetch regional domain (${e.message}). Using default.`);
+  }
+  return "https://directline.botframework.com";
+}
+async function startConversation(domain, token) {
+  log("Starting DirectLine conversation...");
+  const data = await httpPost(
+    `${domain}/v3/directline/conversations`,
+    { Authorization: `Bearer ${token}` },
+    {}
+  );
+  if (!data.conversationId) die("startConversation did not return a conversationId.");
+  return { conversationId: data.conversationId, token: data.token || token };
+}
+async function sendActivity(domain, conversationId, token, activity) {
+  return httpPost(
+    `${domain}/v3/directline/conversations/${conversationId}/activities`,
+    { Authorization: `Bearer ${token}` },
+    activity
+  );
+}
+async function pollActivities(domain, conversationId, token, watermark) {
+  let url = `${domain}/v3/directline/conversations/${conversationId}/activities`;
+  if (watermark !== void 0) {
+    url += `?watermark=${watermark}`;
+  }
+  const data = await httpGet(url, { Authorization: `Bearer ${token}` });
+  return {
+    activities: data.activities || [],
+    watermark: data.watermark
+  };
+}
+function findSignInCard(activities) {
+  for (const activity of activities) {
+    if (activity.type !== "message" || !activity.attachments) continue;
+    for (const att of activity.attachments) {
+      if (att.contentType === "application/vnd.microsoft.card.signin" || att.contentType === "application/vnd.microsoft.card.oauth") {
+        const url = att.content?.buttons?.[0]?.value || att.content?.tokenExchangeResource?.uri || null;
+        if (url) return { signinUrl: url };
+      }
+    }
+  }
+  return null;
+}
+async function promptForAuthCode(signinUrl) {
+  log("");
+  log("Sign-in required.");
+  log(`Open this URL in your browser:
+  ${signinUrl}`);
+  log("After signing in, enter the validation code below.");
+  log("");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr
+  });
+  const code = await new Promise((resolve) => {
+    rl.question("Validation code: ", (answer) => {
+      resolve(answer.trim());
+    });
+  });
+  rl.close();
+  if (!code) die("No validation code received on stdin.");
+  return code;
+}
+async function runPollLoop(domain, conversationId, token, opts) {
+  const timeoutMs = opts && opts.timeoutMs || 3e4;
+  const intervalMs = opts && opts.intervalMs || 1e3;
+  let watermark = opts && opts.watermark;
+  let lastActivityTime = Date.now();
+  let authHandled = false;
+  const allBotActivities = [];
+  while (true) {
+    if (Date.now() - lastActivityTime > timeoutMs) {
+      log("Poll timeout \u2014 no more bot activities.");
+      break;
+    }
+    const result = await pollActivities(domain, conversationId, token, watermark);
+    watermark = result.watermark;
+    const botActivities = result.activities.filter(
+      (a) => a.from && a.from.role !== "user"
+    );
+    for (const activity of botActivities) {
+      lastActivityTime = Date.now();
+      if (activity.type === "endOfConversation") {
+        allBotActivities.push(activity);
+        return { activities: allBotActivities, watermark };
+      }
+      if (!authHandled) {
+        const card = findSignInCard([activity]);
+        if (card) {
+          authHandled = true;
+          if (process.stdin.isTTY) {
+            const code = await promptForAuthCode(card.signinUrl);
+            await sendActivity(domain, conversationId, token, {
+              type: "message",
+              from: { id: "user1", role: "user" },
+              text: code
+            });
+            log("Validation code sent. Waiting for authenticated response...");
+            lastActivityTime = Date.now();
+            continue;
+          } else {
+            allBotActivities.push(activity);
+            return {
+              activities: allBotActivities,
+              watermark,
+              signin: { url: card.signinUrl }
+            };
+          }
+        }
+      }
+      allBotActivities.push(activity);
+    }
+    await sleep(intervalMs);
+  }
+  return { activities: allBotActivities, watermark };
+}
+async function chat(utterance, conversationId, params) {
+  let token;
+  let domain;
+  if (params.mode === "token-endpoint") {
+    token = await fetchToken(params.tokenEndpoint);
+    domain = await getRegionalDomain(params.tokenEndpoint);
+  } else {
+    token = params.directlineSecret;
+    domain = params.directlineDomain || "https://directline.botframework.com";
+    log(`Using DirectLine domain: ${domain}`);
+  }
+  let startActivities = [];
+  let watermark;
+  if (conversationId === null) {
+    const conv = await startConversation(domain, token);
+    conversationId = conv.conversationId;
+    token = conv.token;
+    log(`Conversation started: ${conversationId}`);
+    await sendActivity(domain, conversationId, token, {
+      type: "event",
+      name: "startConversation",
+      from: { id: "user1", role: "user" }
+    });
+    log("startConversation event sent.");
+    const startResult = await runPollLoop(domain, conversationId, token, {
+      timeoutMs: 3e4,
+      intervalMs: 1e3
+    });
+    startActivities = startResult.activities;
+    watermark = startResult.watermark;
+    if (startResult.signin) {
+      log("Sign-in required. Returning sign-in URL for caller to handle.");
+      const connFlag = params.mode === "token-endpoint" ? `--token-endpoint "${params.tokenEndpoint}"` : `--directline-secret "${params.directlineSecret}"`;
+      return {
+        status: "signin_required",
+        signin_url: startResult.signin.url,
+        conversation_id: conversationId,
+        directline_token: token,
+        utterance,
+        start_activities: startActivities,
+        activities: [],
+        watermark,
+        resume_command: `${connFlag} "<VALIDATION_CODE>" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${watermark}"`,
+        followup_command: `${connFlag} "${utterance}" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${watermark}"`
+      };
+    }
+    log(`Received ${startActivities.length} start activities.`);
+  } else {
+    log(`Reusing conversation: ${conversationId}`);
+    if (params.directlineToken) {
+      token = params.directlineToken;
+      log("Using provided DirectLine token.");
+    } else if (params.mode === "token-endpoint") {
+      token = await fetchToken(params.tokenEndpoint);
+    }
+    if (params.watermark) {
+      watermark = params.watermark;
+      log(`Resuming from watermark: ${watermark}`);
+    }
+  }
+  await sendActivity(domain, conversationId, token, {
+    type: "message",
+    from: { id: "user1", role: "user" },
+    text: utterance
+  });
+  log(`Sent: "${utterance}"`);
+  const responseResult = await runPollLoop(domain, conversationId, token, {
+    timeoutMs: 3e4,
+    intervalMs: 1e3,
+    watermark
+  });
+  if (responseResult.signin) {
+    log("Sign-in required. Returning sign-in URL for caller to handle.");
+    const connFlag = params.mode === "token-endpoint" ? `--token-endpoint "${params.tokenEndpoint}"` : `--directline-secret "${params.directlineSecret}"`;
+    return {
+      status: "signin_required",
+      signin_url: responseResult.signin.url,
+      conversation_id: conversationId,
+      directline_token: token,
+      utterance,
+      start_activities: startActivities,
+      activities: responseResult.activities,
+      watermark: responseResult.watermark,
+      resume_command: `${connFlag} "<VALIDATION_CODE>" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${responseResult.watermark}"`,
+      followup_command: `${connFlag} "${utterance}" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${responseResult.watermark}"`
+    };
+  }
+  return {
+    status: "ok",
+    utterance,
+    conversation_id: conversationId,
+    directline_token: token,
+    watermark: responseResult.watermark,
+    start_activities: startActivities,
+    activities: responseResult.activities
+  };
+}
+async function main() {
+  const args = parseArgs();
+  const params = args.tokenEndpoint ? { mode: "token-endpoint", tokenEndpoint: args.tokenEndpoint, directlineToken: args.directlineToken, watermark: args.watermark } : {
+    mode: "directline-secret",
+    directlineSecret: args.directlineSecret,
+    directlineDomain: args.directlineDomain,
+    directlineToken: args.directlineToken,
+    watermark: args.watermark
+  };
+  try {
+    const result = await chat(args.utterance, args.conversationId, params);
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } catch (e) {
+    die(`Unexpected error: ${e.message}`);
+  }
+}
+main();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "description": "Bundled scripts for Copilot Studio plugin",
   "scripts": {
-    "build": "npm run build:schema-lookup && npm run build:chat-with-agent && npm run build:connector-lookup",
+    "build": "npm run build:schema-lookup && npm run build:chat-with-agent && npm run build:connector-lookup && npm run build:directline-chat",
     "build:schema-lookup": "esbuild src/schema-lookup.js --bundle --platform=node --target=node18 --outfile=schema-lookup.bundle.js --format=cjs",
     "build:chat-with-agent": "esbuild src/chat-with-agent.js --bundle --platform=node --target=node18 --outfile=chat-with-agent.bundle.js --format=cjs",
     "build:connector-lookup": "esbuild src/connector-lookup.js --bundle --platform=node --target=node18 --outfile=connector-lookup.bundle.js --format=cjs",
+    "build:directline-chat": "esbuild src/directline-chat.js --bundle --platform=node --target=node18 --outfile=directline-chat.bundle.js --format=cjs",
     "prebuild": "npm install"
   },
   "dependencies": {

--- a/scripts/src/directline-chat.js
+++ b/scripts/src/directline-chat.js
@@ -1,0 +1,449 @@
+/**
+ * directline-chat.js — Send a single utterance to a bot via DirectLine v3 REST API.
+ *
+ * Connection modes:
+ *   --token-endpoint <url>            CPS token endpoint (no auth or with auth/sign-in cards)
+ *   --directline-secret <secret>      Azure Bot Service DirectLine secret
+ *
+ * Usage:
+ *   node directline-chat.bundle.js --token-endpoint <url> "your message"
+ *   node directline-chat.bundle.js --token-endpoint <url> "follow-up" --conversation-id <id>
+ *   node directline-chat.bundle.js --directline-secret <secret> "your message"
+ *   node directline-chat.bundle.js --directline-secret <secret> "your message" --directline-domain <url>
+ *
+ * Output (stdout): single JSON object with full activity payloads
+ * Diagnostics (stderr): human-readable progress lines
+ * Exit codes: 0 = success, 1 = error
+ */
+
+const readline = require("readline");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function log(msg) {
+  process.stderr.write(msg + "\n");
+}
+
+function die(msg) {
+  process.stdout.write(JSON.stringify({ status: "error", error: msg }) + "\n");
+  process.exit(1);
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {
+    utterance: null,
+    conversationId: null,
+    tokenEndpoint: null,
+    directlineSecret: null,
+    directlineDomain: null,
+    directlineToken: null,
+    watermark: null,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--token-endpoint":
+        parsed.tokenEndpoint = args[++i];
+        break;
+      case "--directline-secret":
+        parsed.directlineSecret = args[++i];
+        break;
+      case "--directline-domain":
+        parsed.directlineDomain = args[++i];
+        break;
+      case "--directline-token":
+        parsed.directlineToken = args[++i];
+        break;
+      case "--watermark":
+        parsed.watermark = args[++i];
+        break;
+      case "--conversation-id":
+        parsed.conversationId = args[++i];
+        break;
+      default:
+        if (!args[i].startsWith("--")) {
+          parsed.utterance = args[i];
+        }
+        break;
+    }
+  }
+
+  if (!parsed.utterance) die("Missing utterance argument.");
+  if (!parsed.tokenEndpoint && !parsed.directlineSecret) {
+    die("Missing connection: provide --token-endpoint or --directline-secret.");
+  }
+  if (parsed.tokenEndpoint && parsed.directlineSecret) {
+    die("Provide only one of --token-endpoint or --directline-secret, not both.");
+  }
+
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+async function httpGet(url, headers) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    die(`HTTP ${res.status} from GET ${url}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function httpPost(url, headers, body) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    die(`HTTP ${res.status} from POST ${url}: ${text.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Token & regional domain
+// ---------------------------------------------------------------------------
+
+async function fetchToken(tokenEndpointUrl) {
+  log("Fetching DirectLine token from token endpoint...");
+  const data = await httpGet(tokenEndpointUrl, {});
+  if (!data.token) die("Token endpoint did not return a token.");
+  return data.token;
+}
+
+async function getRegionalDomain(tokenEndpointUrl) {
+  try {
+    const parsed = new URL(tokenEndpointUrl);
+    const settingsUrl =
+      parsed.origin +
+      "/powervirtualagents/regionalchannelsettings?api-version=2022-03-01-preview";
+    log("Fetching regional DirectLine domain...");
+    const data = await httpGet(settingsUrl, {});
+    const domain = data.channelUrlsById?.directline?.replace(/\/+$/, "");
+    if (domain) {
+      log(`Regional domain: ${domain}`);
+      return domain;
+    }
+  } catch (e) {
+    log(`Warning: Could not fetch regional domain (${e.message}). Using default.`);
+  }
+  return "https://directline.botframework.com";
+}
+
+// ---------------------------------------------------------------------------
+// DirectLine v3 API
+// ---------------------------------------------------------------------------
+
+async function startConversation(domain, token) {
+  log("Starting DirectLine conversation...");
+  const data = await httpPost(
+    `${domain}/v3/directline/conversations`,
+    { Authorization: `Bearer ${token}` },
+    {}
+  );
+  if (!data.conversationId) die("startConversation did not return a conversationId.");
+  return { conversationId: data.conversationId, token: data.token || token };
+}
+
+async function sendActivity(domain, conversationId, token, activity) {
+  return httpPost(
+    `${domain}/v3/directline/conversations/${conversationId}/activities`,
+    { Authorization: `Bearer ${token}` },
+    activity
+  );
+}
+
+async function pollActivities(domain, conversationId, token, watermark) {
+  let url = `${domain}/v3/directline/conversations/${conversationId}/activities`;
+  if (watermark !== undefined) {
+    url += `?watermark=${watermark}`;
+  }
+  const data = await httpGet(url, { Authorization: `Bearer ${token}` });
+  return {
+    activities: data.activities || [],
+    watermark: data.watermark,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sign-in detection
+// ---------------------------------------------------------------------------
+
+function findSignInCard(activities) {
+  for (const activity of activities) {
+    if (activity.type !== "message" || !activity.attachments) continue;
+    for (const att of activity.attachments) {
+      if (
+        att.contentType === "application/vnd.microsoft.card.signin" ||
+        att.contentType === "application/vnd.microsoft.card.oauth"
+      ) {
+        const url =
+          att.content?.buttons?.[0]?.value ||
+          att.content?.tokenExchangeResource?.uri ||
+          null;
+        if (url) return { signinUrl: url };
+      }
+    }
+  }
+  return null;
+}
+
+async function promptForAuthCode(signinUrl) {
+  log("");
+  log("Sign-in required.");
+  log(`Open this URL in your browser:\n  ${signinUrl}`);
+  log("After signing in, enter the validation code below.");
+  log("");
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+
+  const code = await new Promise((resolve) => {
+    rl.question("Validation code: ", (answer) => {
+      resolve(answer.trim());
+    });
+  });
+  rl.close();
+
+  if (!code) die("No validation code received on stdin.");
+  return code;
+}
+
+// ---------------------------------------------------------------------------
+// Poll loop
+// ---------------------------------------------------------------------------
+
+async function runPollLoop(domain, conversationId, token, opts) {
+  const timeoutMs = (opts && opts.timeoutMs) || 30000;
+  const intervalMs = (opts && opts.intervalMs) || 1000;
+  let watermark = opts && opts.watermark;
+
+  let lastActivityTime = Date.now();
+  let authHandled = false;
+  const allBotActivities = [];
+
+  while (true) {
+    if (Date.now() - lastActivityTime > timeoutMs) {
+      log("Poll timeout — no more bot activities.");
+      break;
+    }
+
+    const result = await pollActivities(domain, conversationId, token, watermark);
+    watermark = result.watermark;
+
+    const botActivities = result.activities.filter(
+      (a) => a.from && a.from.role !== "user"
+    );
+
+    for (const activity of botActivities) {
+      lastActivityTime = Date.now();
+
+      if (activity.type === "endOfConversation") {
+        allBotActivities.push(activity);
+        return { activities: allBotActivities, watermark };
+      }
+
+      // Sign-in detection
+      if (!authHandled) {
+        const card = findSignInCard([activity]);
+        if (card) {
+          authHandled = true;
+
+          if (process.stdin.isTTY) {
+            // Interactive terminal — prompt for code on stdin
+            const code = await promptForAuthCode(card.signinUrl);
+            await sendActivity(domain, conversationId, token, {
+              type: "message",
+              from: { id: "user1", role: "user" },
+              text: code,
+            });
+            log("Validation code sent. Waiting for authenticated response...");
+            lastActivityTime = Date.now();
+            continue;
+          } else {
+            // Non-interactive (e.g., Claude Bash tool) — return sign-in info in output
+            // Include the sign-in activity so caller can see it, then exit the poll loop
+            allBotActivities.push(activity);
+            return {
+              activities: allBotActivities,
+              watermark,
+              signin: { url: card.signinUrl },
+            };
+          }
+        }
+      }
+
+      allBotActivities.push(activity);
+    }
+
+    await sleep(intervalMs);
+  }
+
+  return { activities: allBotActivities, watermark };
+}
+
+// ---------------------------------------------------------------------------
+// Chat orchestrator
+// ---------------------------------------------------------------------------
+
+async function chat(utterance, conversationId, params) {
+  let token;
+  let domain;
+
+  if (params.mode === "token-endpoint") {
+    token = await fetchToken(params.tokenEndpoint);
+    domain = await getRegionalDomain(params.tokenEndpoint);
+  } else {
+    token = params.directlineSecret;
+    domain = params.directlineDomain || "https://directline.botframework.com";
+    log(`Using DirectLine domain: ${domain}`);
+  }
+
+  let startActivities = [];
+  let watermark;
+
+  if (conversationId === null) {
+    const conv = await startConversation(domain, token);
+    conversationId = conv.conversationId;
+    token = conv.token; // Use refreshed token
+    log(`Conversation started: ${conversationId}`);
+
+    // Send startConversation event to trigger welcome message
+    await sendActivity(domain, conversationId, token, {
+      type: "event",
+      name: "startConversation",
+      from: { id: "user1", role: "user" },
+    });
+    log("startConversation event sent.");
+
+    const startResult = await runPollLoop(domain, conversationId, token, {
+      timeoutMs: 30000,
+      intervalMs: 1000,
+    });
+    startActivities = startResult.activities;
+    watermark = startResult.watermark;
+
+    // If sign-in required in non-interactive mode, return early with sign-in info
+    if (startResult.signin) {
+      log("Sign-in required. Returning sign-in URL for caller to handle.");
+      const connFlag = params.mode === "token-endpoint"
+        ? `--token-endpoint "${params.tokenEndpoint}"`
+        : `--directline-secret "${params.directlineSecret}"`;
+      return {
+        status: "signin_required",
+        signin_url: startResult.signin.url,
+        conversation_id: conversationId,
+        directline_token: token,
+        utterance,
+        start_activities: startActivities,
+        activities: [],
+        watermark,
+        resume_command: `${connFlag} "<VALIDATION_CODE>" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${watermark}"`,
+        followup_command: `${connFlag} "${utterance}" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${watermark}"`,
+      };
+    }
+
+    log(`Received ${startActivities.length} start activities.`);
+  } else {
+    log(`Reusing conversation: ${conversationId}`);
+    // Use provided DirectLine token if available (bound to this conversation)
+    if (params.directlineToken) {
+      token = params.directlineToken;
+      log("Using provided DirectLine token.");
+    } else if (params.mode === "token-endpoint") {
+      token = await fetchToken(params.tokenEndpoint);
+    }
+    // Use provided watermark to skip already-seen activities
+    if (params.watermark) {
+      watermark = params.watermark;
+      log(`Resuming from watermark: ${watermark}`);
+    }
+  }
+
+  // Send user message
+  await sendActivity(domain, conversationId, token, {
+    type: "message",
+    from: { id: "user1", role: "user" },
+    text: utterance,
+  });
+  log(`Sent: "${utterance}"`);
+
+  const responseResult = await runPollLoop(domain, conversationId, token, {
+    timeoutMs: 30000,
+    intervalMs: 1000,
+    watermark,
+  });
+
+  // Sign-in could also happen after sending the user message
+  if (responseResult.signin) {
+    log("Sign-in required. Returning sign-in URL for caller to handle.");
+    const connFlag = params.mode === "token-endpoint"
+      ? `--token-endpoint "${params.tokenEndpoint}"`
+      : `--directline-secret "${params.directlineSecret}"`;
+    return {
+      status: "signin_required",
+      signin_url: responseResult.signin.url,
+      conversation_id: conversationId,
+      directline_token: token,
+      utterance,
+      start_activities: startActivities,
+      activities: responseResult.activities,
+      watermark: responseResult.watermark,
+      resume_command: `${connFlag} "<VALIDATION_CODE>" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${responseResult.watermark}"`,
+      followup_command: `${connFlag} "${utterance}" --conversation-id "${conversationId}" --directline-token "${token}" --watermark "${responseResult.watermark}"`,
+    };
+  }
+
+  return {
+    status: "ok",
+    utterance,
+    conversation_id: conversationId,
+    directline_token: token,
+    watermark: responseResult.watermark,
+    start_activities: startActivities,
+    activities: responseResult.activities,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs();
+
+  const params = args.tokenEndpoint
+    ? { mode: "token-endpoint", tokenEndpoint: args.tokenEndpoint, directlineToken: args.directlineToken, watermark: args.watermark }
+    : {
+        mode: "directline-secret",
+        directlineSecret: args.directlineSecret,
+        directlineDomain: args.directlineDomain,
+        directlineToken: args.directlineToken,
+        watermark: args.watermark,
+      };
+
+  try {
+    const result = await chat(args.utterance, args.conversationId, params);
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } catch (e) {
+    die(`Unexpected error: ${e.message}`);
+  }
+}
+
+main();

--- a/skills/_project-context/SKILL.md
+++ b/skills/_project-context/SKILL.md
@@ -78,7 +78,8 @@ You have access to specialized skills that handle YAML creation, editing, valida
 | `/copilot-studio:list-kinds` | List all valid kind values |
 | `/copilot-studio:list-topics` | List all topics in the agent |
 | `/copilot-studio:run-tests` | Run tests against a published agent |
-| `/copilot-studio:chat-with-agent` | Send a test message to a published agent |
+| `/copilot-studio:chat-with-agent` | Send a test message to a published agent (M365 SDK) |
+| `/copilot-studio:directline-chat` | Send a test message via DirectLine v3 REST (token endpoint or secret) |
 | `/copilot-studio:known-issues` | Search the known-issues KB (GitHub label: kb) for symptoms and mitigations |
 
 **If no skill matches**, only then work manually — but always validate with `/copilot-studio:validate` afterward.

--- a/skills/directline-chat/SKILL.md
+++ b/skills/directline-chat/SKILL.md
@@ -1,0 +1,168 @@
+---
+user-invocable: false
+description: Send a message to a bot via DirectLine v3 REST API and get the full response. Use when the user has a DirectLine secret or Copilot Studio token endpoint URL. Supports auth/sign-in flows via OAuthCard detection.
+argument-hint: <utterance to send>
+allowed-tools: Bash(node *directline-chat.bundle.js *), Read, Glob, Grep
+context: fork
+agent: test
+---
+
+# DirectLine Chat
+
+Send a single utterance to a bot via the DirectLine v3 REST API and display its full response. Works with any bot reachable via DirectLine — either through a Copilot Studio token endpoint (no Azure app registration needed) or a raw DirectLine secret.
+
+## Connection Modes
+
+| Mode | When to use | What you need |
+|------|-------------|--------------|
+| **Token endpoint** | Agent published in Copilot Studio with Direct Line channel | Copilot Studio token endpoint URL |
+| **DirectLine secret** | Azure Bot Service bot with DirectLine channel enabled | DirectLine secret from Azure Portal |
+
+## Phase 0: Resolve Connection Parameters
+
+Ask the user which mode to use if not already clear from `$ARGUMENTS`:
+
+- **Token endpoint mode**: "What is your Copilot Studio token endpoint URL? It looks like `https://...api.powerplatform.com/powervirtualagents/botsbyschema/.../directline/token?api-version=2022-03-01-preview`"
+- **DirectLine secret mode**: "What is your DirectLine secret? Find it in Azure Portal > Bot Service > Channels > DirectLine > Secret keys."
+
+Remember the token endpoint or secret for the entire conversation — you will need it for follow-up messages and auth flows.
+
+## Phase 1: Send Utterance
+
+### Token endpoint mode
+
+```bash
+node ${CLAUDE_SKILL_DIR}/../../scripts/directline-chat.bundle.js \
+  --token-endpoint "<url>" "<utterance>"
+```
+
+### DirectLine secret mode
+
+```bash
+node ${CLAUDE_SKILL_DIR}/../../scripts/directline-chat.bundle.js \
+  --directline-secret "<secret>" "<utterance>"
+```
+
+With optional domain override:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/../../scripts/directline-chat.bundle.js \
+  --directline-secret "<secret>" \
+  --directline-domain "https://directline.botframework.com" \
+  "<utterance>"
+```
+
+The script outputs:
+- **stderr**: diagnostic messages (token fetch, conversation start, poll progress)
+- **stdout**: a single JSON object with the full result
+
+### Parse the JSON output
+
+The output has one of three `status` values:
+
+#### `status: "ok"` — Normal response
+
+```json
+{
+  "status": "ok",
+  "utterance": "hello",
+  "conversation_id": "abc123-XYZ",
+  "start_activities": [ ... ],
+  "activities": [ ... ]
+}
+```
+
+#### `status: "signin_required"` — Bot requires authentication
+
+```json
+{
+  "status": "signin_required",
+  "signin_url": "https://token.botframework.com/api/oauth/signin?signin=...",
+  "conversation_id": "abc123-XYZ",
+  "directline_token": "eyJ...",
+  "utterance": "hello",
+  "start_activities": [ ... ],
+  "activities": [],
+  "resume_command": "--token-endpoint \"<url>\" \"<VALIDATION_CODE>\" --conversation-id \"abc123-XYZ\" --directline-token \"eyJ...\"",
+  "followup_command": "--token-endpoint \"<url>\" \"hello\" --conversation-id \"abc123-XYZ\" --directline-token \"eyJ...\""
+}
+```
+
+**CRITICAL: When you see `signin_required`, follow the Auth Flow below. Do NOT start a new conversation. The response includes `resume_command` and `followup_command` with the exact arguments to use — just substitute the validation code and run them.**
+
+#### `status: "error"` — Error
+
+```json
+{ "status": "error", "error": "..." }
+```
+
+## Auth Flow (Sign-In Required)
+
+When `status` is `"signin_required"`, the bot requires the user to authenticate. Follow these steps exactly:
+
+1. **Show the sign-in URL** to the user:
+
+   > **Sign-in Required**
+   >
+   > The bot requires authentication. Open this URL in your browser:
+   > [signin_url from the response]
+   >
+   > After signing in, you'll see a validation code. Paste it here.
+
+2. **Wait for the user to provide the validation code.**
+
+3. **Send the validation code** — take `resume_command` from the JSON output, replace `<VALIDATION_CODE>` with the user's code, and run:
+
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/../../scripts/directline-chat.bundle.js <resume_command with code substituted>
+   ```
+
+   Do NOT construct the command yourself. Use `resume_command` exactly as given — it already contains the correct `--conversation-id` and `--directline-token`.
+
+4. **Send the original utterance** — take `followup_command` from the JSON output and run:
+
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/../../scripts/directline-chat.bundle.js <followup_command>
+   ```
+
+   This sends the user's original message in the now-authenticated conversation.
+
+### Display the result
+
+Extract from `activities`:
+
+- **Text responses**: `type === "message"` — show `text`
+- **Suggested actions**: `suggestedActions.actions` array
+- **Adaptive cards**: `attachments` with `contentType === "application/vnd.microsoft.card.adaptive"`
+
+Show a summary like:
+
+> **Agent response:**
+> [message text]
+>
+> **Suggested actions:** action1 · action2 _(omit if empty)_
+
+## Phase 2: Multi-Turn Sequences
+
+Pass `--conversation-id` and `--directline-token` from the previous response:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/../../scripts/directline-chat.bundle.js \
+  --token-endpoint "<url>" "<follow-up>" \
+  --conversation-id <id> --directline-token "<token>"
+```
+
+**Always pass `--directline-token`** when resuming a conversation. DirectLine tokens are bound to the conversation that created them — a new token from the token endpoint will fail with "Token not valid for this conversation". The `directline_token` field is included in every response for this purpose.
+
+DirectLine tokens expire (~30 min). If the token expires, start a new conversation.
+
+When the user says "continue the conversation" or "send a follow-up", reuse `conversation_id` automatically.
+
+## Error Handling
+
+| Error message | Likely cause | What to tell the user |
+|---|---|---|
+| `Token endpoint rejected` | Agent not published or wrong URL | Verify agent is published and URL is correct |
+| `DirectLine authentication failed` | Wrong secret or expired token | Check the DirectLine secret |
+| `Conversation not found` | Conversation expired (>30 min) | Start a new conversation without `--conversation-id` |
+| `Network error` | Connectivity issue | Check network and endpoint URL |


### PR DESCRIPTION
## Summary
- Add `directline-chat` script and skill for testing bots via DirectLine v3 REST API
- Supports CPS token endpoint (with/without OAuth sign-in) and DirectLine secret modes
- Pure HTTP (fetch), 11KB bundle, no new dependencies
- Auto-fetches regional DirectLine domain from CPS token endpoints
- Handles OAuth sign-in card flow: detects OAuthCard, returns `signin_required` with `resume_command`/`followup_command` for the caller
- Tracks conversation state via `--conversation-id`, `--directline-token`, `--watermark` for multi-turn and auth resumption

Closes #54

## Test plan
- [x] `--token-endpoint` with non-auth agent (books-search): greeting + response received
- [x] `--token-endpoint` with auth agent (FIC): sign-in card detected, `signin_required` returned with resume commands
- [x] Watermark prevents re-seeing old OAuthCard on resume
- [x] Regional domain auto-detected (unitedstates.directline.botframework.com)
- [x] Double-slash in domain URL fixed
- [ ] Full auth round-trip: sign in → validation code → authenticated response

🤖 Generated with [Claude Code](https://claude.com/claude-code)