### PR TITLE
Document non-functional triggers and YAML-only features

### DIFF
--- a/skills/add-knowledge/knowledge-guide.md
+++ b/skills/add-knowledge/knowledge-guide.md
@@ -147,7 +147,9 @@ Use the template at `templates/knowledge/graph-connector.knowledge.mcs.yml`.
 
 Every knowledge source supports an optional `triggerCondition` field (a Power Fx `BoolExpression`). The `UniversalSearchTool` only includes the source in a search when this condition evaluates to `true`.
 
-**`triggerCondition: =false`** — the most important pattern. It permanently disables automatic search for this source. The orchestrator will never include it in the `UniversalSearchTool` automatically. This is useful for:
+The Copilot Studio UI exposes `triggerCondition` as an on/off toggle — excluding a source from `UniversalSearchTool` sets `triggerCondition: =false`. Via YAML, `triggerCondition` can be set to any Power Fx expression, which is fully functional at runtime but not visible or editable in the UI.
+
+**`triggerCondition: =false`** — the most common pattern. It permanently disables automatic search for this source. The orchestrator will never include it in the `UniversalSearchTool` automatically. This is useful for:
 
 1. **Explicit topic-controlled search** — the source is only used when a topic explicitly references it in a `SearchAndSummarizeContent` node. Gives you full control over when and how the source is queried.
 
@@ -156,12 +158,13 @@ Every knowledge source supports an optional `triggerCondition` field (a Power Fx
 3. **`OnKnowledgeRequested` topic** — a topic with this trigger fires every time the orchestrator calls the `UniversalSearchTool`. Combined with `triggerCondition: =false`, you can intercept all knowledge requests and route them through custom logic before the search runs. It extends the knowledge retrieval with a more controled approach but it adds latency as it adds and extra search in the knowledge retrieval pipeline. Try to use it only when you need to run custom logic on every search request, and it is good to put a condition on the trigger to only run it when is really needed (e.g. only for users in the HR department, or only for certain types of queries).
 
 ```yaml
-# Example: source only searched for HR department users
+# Name: Armstrong County Knowledge Base
+# UPMC employee information specific to Armstrong county, only searched when the user is located in Armstrong.
 kind: KnowledgeSourceConfiguration
 source:
   kind: SharePointSearchSource
-  triggerCondition: =Global.UserDepartment = "HR"
-  site: https://contoso.sharepoint.com/sites/HR/Shared%20Documents
+  triggerCondition: =Global.UserCounty = "Armstrong"
+  site: https://pplatform.sharepoint.com/sites/KnowledgeBase/Shared%20Documents/UPMC_By_County/Armstrong
 ```
 
 ```yaml

--- a/skills/int-reference/SKILL.md
+++ b/skills/int-reference/SKILL.md
@@ -41,6 +41,15 @@ System triggers (`OnConversationStart`, `OnUnknownIntent`, `OnError`, etc.) fire
 | `OnToolSelected` | Child agent invocation |
 | `OnKnowledgeRequested` | Custom knowledge source search triggered (YAML-only, no UI) |
 | `OnGeneratedResponse` | Intercept AI-generated response before sending |
+| `OnOutgoingMessage` | **Non-functional (2026-03-15)** — exists in schema but does not fire at runtime. Do not use. |
+
+### YAML-Only Features
+
+These features work at runtime but are **not visible in the Copilot Studio UI**. Warn users that UI edits may silently remove them.
+
+| Feature | Notes |
+|---------|-------|
+| `triggerCondition` on knowledge sources | The UI only exposes this as an on/off toggle (`=false` to exclude from `UniversalSearchTool`). Arbitrary Power Fx expressions (e.g., `=Global.UserDepartment = "HR"`) work at runtime but can only be set via YAML. Use with caution. (2026-03-16) |
 
 ## Action Types
 


### PR DESCRIPTION
## Summary

- Mark `OnOutgoingMessage` trigger as non-functional in the reference tables (fixes #67)
- Add "YAML-Only Features" section to `int-reference/SKILL.md` documenting that `triggerCondition` on knowledge sources supports arbitrary Power Fx expressions via YAML, while the UI only exposes an on/off toggle
- Update `knowledge-guide.md` with clarification and real-world county-based example

## Test plan

- [ ] Verify author agent no longer suggests `OnOutgoingMessage` as a valid trigger
- [ ] Verify author agent warns about YAML-only nature of arbitrary `triggerCondition` expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)