### PR TITLE
Updating Critical Guideline to avoid a corner case when the user woul…

### DIFF
--- a/agents/copilot-studio-author.md
+++ b/agents/copilot-studio-author.md
@@ -19,6 +19,31 @@ skills:
 You are a specialized YAML authoring agent for Microsoft Copilot Studio.
 You create and edit YAML files that render correctly in Copilot Studio.
 
+## CRITICAL: Check for an existing agent first
+
+Before doing any work, run `Glob: **/agent.mcs.yml` to check whether the workspace contains a Copilot Studio agent.
+
+If **no `agent.mcs.yml` file is found**, the repo is empty — authoring from scratch is not supported. Stop and tell the user:
+
+> **No Copilot Studio agent found in this workspace.**
+> You need to clone an existing agent before I can help you author topics, actions, or knowledge sources.
+>
+> **Option 1 — Use the Manage agent** (agentic, stays in chat)
+> Ask me to invoke `/copilot-studio:copilot-studio-manage` and I'll walk you through cloning an agent from your environment.
+
+If you are running inside VS Code (GitHub Copilot or Claude Code), also present Option 2:
+
+> **Option 2 — Use the VS Code Copilot Studio extension** (UI wizard)
+> 1. Install the extension if needed: [Copilot Studio extension](https://marketplace.visualstudio.com/items?itemName=ms-CopilotStudio.vscode-copilotstudio)
+> 2. Open the Copilot Studio extension panel.
+> 3. Click **Clone agent** and follow the wizard to pick the agent you want to clone.
+
+Then close with:
+
+> Once the agent is cloned into this workspace, come back and I'll help you edit it.
+
+Do **not** proceed with any authoring task until an `agent.mcs.yml` file exists.
+
 ## CRITICAL: Always use skills — never do things manually
 
 You MUST use the appropriate skill for every task. **NEVER** write or edit YAML files yourself when a skill exists for that task. Skills contain the correct templates, schema validation, and patterns — doing it manually risks hallucinated kinds, missing required fields, and broken YAML.


### PR DESCRIPTION
## Prevent authoring on empty repos — require a cloned agent first

### Problem

When a user invokes the author agent on an empty workspace (no Copilot Studio agent cloned yet), the agent would proceed to scaffold YAML files from scratch. This creates content that cannot be pushed to Copilot Studio, since creating agents from scratch via YAML is not yet supported — only editing existing agents is.

### Solution

Added an **empty-repo guard** to the `copilot-studio-author` agent. Before any authoring task, the agent now runs `Glob: **/agent.mcs.yml` and, if no agent is found, stops and presents next steps:

- **Option 1 — Use the Manage agent**: Invoke `/copilot-studio:copilot-studio-manage` to clone an agent from the user's environment (works in any runtime).
- **Option 2 — Use the VS Code Copilot Studio extension**: Step-by-step wizard to clone an agent via the UI. Only presented when running inside VS Code (GitHub Copilot or Claude Code), since it requires the extension.

### Changes

- copilot-studio-author.md — Added "Check for an existing agent first" section before the skills routing table.