### PR TITLE
Fix API permission search term in setup docs

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -124,7 +124,7 @@ The test agent (`/copilot-studio:test`) supports three ways to test:
 Send a single utterance directly to the published agent and see its full response. Requires an **Azure App Registration**:
 - **Platform**: Public client / Native (Mobile and desktop applications)
 - **Redirect URI**: `http://localhost` (HTTP, not HTTPS)
-- **API permissions**: `CopilotStudio.Copilots.Invoke` (granted by admin)
+- **API permissions**: Add a permission → APIs my organization uses → search **Power Platform API** → Delegated permissions → expand CopilotStudio → check `CopilotStudio.Copilots.Invoke` (optionally grant admin consent)
 
 ```
 /copilot-studio:test Send "What products do you offer?" to the published agent

--- a/skills/chat-with-agent/SKILL.md
+++ b/skills/chat-with-agent/SKILL.md
@@ -18,7 +18,7 @@ Send a single utterance to a published Copilot Studio agent and display its full
 2. An **Azure App Registration** configured as follows:
    - **Platform**: Public client / Native (Mobile and desktop applications) — NOT SPA
    - **Redirect URI**: `http://localhost` (HTTP, not HTTPS)
-   - **API permissions**: `CopilotStudio.Copilots.Invoke` (granted by admin)
+   - **API permissions**: Add a permission → APIs my organization uses → search **Power Platform API** → Delegated permissions → expand CopilotStudio → check `CopilotStudio.Copilots.Invoke` (optionally grant admin consent)
    - This uses MSAL device-code flow, which requires a public client
 
 ## Phase 0: Resolve Client ID


### PR DESCRIPTION
## Summary
- The setup instructions referenced incorrect API names ("Power Virtual Agents" / "CopilotStudio") when describing how to add API permissions in the Azure portal — these return no results
- Updated both `SETUP_GUIDE.md` and `skills/chat-with-agent/SKILL.md` with the correct step-by-step flow: search **Power Platform API** → Delegated permissions → expand CopilotStudio → check `CopilotStudio.Copilots.Invoke`

Fixes #73

## Test plan
- [ ] Follow the updated instructions in the Azure portal and verify the permission can be found and added

🤖 Generated with [Claude Code](https://claude.com/claude-code)