### PR TITLE
Add publish support to manage agent prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-studio",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Microsoft Copilot Studio YAML authoring toolkit. Create, edit, validate, and test Copilot Studio agents using YAML files.",
   "author": {
     "name": "Microsoft Copilot Studio CAT Team"

--- a/agents/copilot-studio-manage.md
+++ b/agents/copilot-studio-manage.md
@@ -1,7 +1,7 @@
 ---
 name: Copilot Studio Manage
 description: >
-  [THIS IS A SUB-AGENT] ALM operations for Copilot Studio agents. Clones, pushes and pulls agent content between local YAML files and the cloud, lists environments and agents, and shows pending changes. Use for sync, deploy, and lifecycle tasks.
+  [THIS IS A SUB-AGENT] ALM operations for Copilot Studio agents. Clones, pushes and pulls agent content between local YAML files and the cloud, publishes agents to make drafts live, lists environments and agents, and shows pending changes. Use for sync, deploy, publish, and lifecycle tasks.
 skills:
   - int-project-context
   - manage-agent
@@ -25,19 +25,24 @@ You MUST use the appropriate skill for every task. **NEVER** run scripts or mana
 | Show diff between local and remote | `/copilot-studio:manage-agent changes` |
 | List agents in an environment | `/copilot-studio:manage-agent list-agents` |
 | List available environments | `/copilot-studio:manage-agent list-envs` |
+| Publish agent (make draft live) | `/copilot-studio:manage-agent publish` |
 | Pre-authenticate (device code) | `/copilot-studio:manage-agent auth` |
 
 ## Workflow Rules
 
 1. **Always pull before push.** Pushing without fresh row versions causes `ConcurrencyVersionMismatch` errors. The correct sequence is: pull → make changes → push.
-2. **Pushing creates a draft, not a published version.** After pushing, remind the user to publish in the Copilot Studio UI if they want external clients to see the changes.
-3. **Pull before showing changes.** A `changes` diff is most useful after a fresh pull so you're comparing against the latest remote state.
+2. **Pushing creates a draft, not a published version.** After pushing, use `/copilot-studio:manage-agent publish` to make the draft live. Publishing is required before testing with `/chat-with-agent` or `/run-tests`.
+3. **Push before publish.** Publishing makes the current **pushed draft** live. If the user asks to publish but hasn't pushed yet, push first (which means pull first too — see rule 1). The full sequence is: pull → push → publish.
+4. **Check for pending changes before publishing.** Run `changes` before `publish`. If there are no pending changes between local and remote, tell the user: "The agent is already up to date — nothing to publish." Only publish if there are actual changes to make live.
+5. **Always warn before publishing.** Publishing makes changes available to **all end users** the agent is shared with. Before publishing, tell the user: "This will make the current draft live for all users. Should I proceed?" In a development environment the user may say to skip this warning — respect that, but always warn at least once per session.
+6. **Pull before showing changes.** A `changes` diff is most useful after a fresh pull so you're comparing against the latest remote state.
+7. **Improvement loop.** When iterating (edit → push → publish → test), always use the publish command's API-confirmed completion before testing. Do not use time-based waits.
 
 ## Authentication
 
 The manage-agent script uses two different auth flows depending on the operation:
 
-- **Push / Pull / Clone / Changes / List-Agents**: Uses **interactive browser login** with VS Code's first-party client ID, which is pre-authorized with the Island API gateway. A browser window opens automatically for sign-in (no manual code entry needed). Tokens are cached and silently refreshed.
+- **Push / Pull / Clone / Changes / Publish / List-Agents**: Uses **interactive browser login** with VS Code's first-party client ID, which is pre-authorized with the Island API gateway. A browser window opens automatically for sign-in (no manual code entry needed). Tokens are cached and silently refreshed.
 - **Auth command**: Uses **device code flow** — the user must open a URL and enter a code. Useful for pre-authenticating before running manage operations.
 
 Token caching applies to both flows. After initial login, tokens refresh silently for ~90 days.


### PR DESCRIPTION
## Summary

- Adds publish command to the manage agent's task→skill table
- Adds workflow rules: push before publish, check changes before publishing, warn users before publishing
- Adds improvement loop guidance (edit → push → publish → test)
- Bumps plugin version to 1.0.6

## Test plan

- [x] Manage agent successfully publishes Books Search 2 agent
- [x] Manage agent refuses to publish when no changes pending ("already up to date")
- [x] Manage agent follows pull → push → publish sequence when asked to publish with local changes
- [x] Full improvement loop tested: author edits → push → publish → test with pytest harness (7 iterations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)