### PR TITLE
fix: schema-driven validation for inputs placement and action kinds

### DIFF
--- a/scripts/schema-lookup.bundle.js
+++ b/scripts/schema-lookup.bundle.js
@@ -2921,6 +2921,49 @@ function findKindValues(definitions) {
   }
   return [...kinds].sort();
 }
+function getValidKindsFromOneOf(definitionName, definitions) {
+  const def = definitions[definitionName];
+  if (!def || !def.oneOf) return [];
+  const kinds = [];
+  for (const entry of def.oneOf) {
+    const ref = entry.$ref;
+    if (ref && ref.startsWith("#/definitions/")) {
+      const refName = ref.slice("#/definitions/".length);
+      const refDef = definitions[refName];
+      if (refDef && refDef.properties && refDef.properties.kind) {
+        const kindProp = refDef.properties.kind;
+        if (kindProp.const) kinds.push(kindProp.const);
+        if (kindProp.enum) kinds.push(...kindProp.enum);
+      }
+    }
+  }
+  return kinds;
+}
+function getValidProperties(definitionName, definitions) {
+  const def = definitions[definitionName];
+  if (!def) return /* @__PURE__ */ new Set();
+  if (def.properties) {
+    return new Set(Object.keys(def.properties));
+  }
+  if (def.oneOf) {
+    const allProps = /* @__PURE__ */ new Set();
+    for (const entry of def.oneOf) {
+      const ref = entry.$ref;
+      if (ref && ref.startsWith("#/definitions/")) {
+        const refName = ref.slice("#/definitions/".length);
+        const refDef = definitions[refName];
+        if (refDef && refDef.properties) {
+          Object.keys(refDef.properties).forEach((p) => allProps.add(p));
+        }
+      }
+      if (entry.properties) {
+        Object.keys(entry.properties).forEach((p) => allProps.add(p));
+      }
+    }
+    return allProps;
+  }
+  return /* @__PURE__ */ new Set();
+}
 function formatDefinition(name, definition, compact) {
   if (!compact) {
     return JSON.stringify({ [name]: definition }, null, 2);
@@ -3072,6 +3115,41 @@ function validateYamlFile(filepath, definitions) {
     } else {
       console.log("[WARN] Missing settings.instructions \u2014 child agents need instructions for generative orchestration");
       warnings++;
+    }
+  }
+  if (kind && data.beginDialog && typeof data.beginDialog === "object") {
+    const bd = data.beginDialog;
+    const triggerKind = bd.kind;
+    if (Array.isArray(bd.actions)) {
+      const validActionKinds = getValidKindsFromOneOf("DialogAction", definitions);
+      if (validActionKinds.length > 0) {
+        for (const action of bd.actions) {
+          if (action && typeof action === "object" && action.kind) {
+            if (validActionKinds.includes(action.kind)) {
+              passes++;
+            } else {
+              console.log(
+                `[FAIL] '${action.kind}' is not a valid action kind inside beginDialog.actions (not found in DialogAction schema definition). Use 'schema-lookup.bundle.js resolve DialogAction' to see valid action kinds.`
+              );
+              failures++;
+            }
+          }
+        }
+      }
+    }
+    if (triggerKind) {
+      const triggerProps = getValidProperties(triggerKind, definitions);
+      const rootDef = definitions[kind];
+      const rootProps = rootDef && rootDef.properties ? new Set(Object.keys(rootDef.properties)) : /* @__PURE__ */ new Set();
+      for (const key of Object.keys(bd)) {
+        if (key === "kind" || key === "id") continue;
+        if (!triggerProps.has(key) && rootProps.has(key)) {
+          console.log(
+            `[FAIL] '${key}' is inside beginDialog but belongs at the ${kind} root level (not a valid property of ${triggerKind}, but is a property of ${kind}). Move '${key}' to the top level of the YAML.`
+          );
+          failures++;
+        }
+      }
     }
   }
   const idsFound = [];

--- a/scripts/src/schema-lookup.js
+++ b/scripts/src/schema-lookup.js
@@ -198,6 +198,65 @@ function findKindValues(definitions) {
   return [...kinds].sort();
 }
 
+// --- Schema-driven structural helpers ---
+
+/**
+ * Extracts valid kind values from a oneOf definition in the schema.
+ * For example, DialogAction.oneOf contains refs to all valid action kinds.
+ */
+function getValidKindsFromOneOf(definitionName, definitions) {
+  const def = definitions[definitionName];
+  if (!def || !def.oneOf) return [];
+
+  const kinds = [];
+  for (const entry of def.oneOf) {
+    const ref = entry.$ref;
+    if (ref && ref.startsWith("#/definitions/")) {
+      const refName = ref.slice("#/definitions/".length);
+      const refDef = definitions[refName];
+      if (refDef && refDef.properties && refDef.properties.kind) {
+        const kindProp = refDef.properties.kind;
+        if (kindProp.const) kinds.push(kindProp.const);
+        if (kindProp.enum) kinds.push(...kindProp.enum);
+      }
+    }
+  }
+  return kinds;
+}
+
+/**
+ * Gets the set of valid property names for a definition (resolving oneOf refs).
+ * For union types (oneOf), returns the union of all properties across all variants.
+ */
+function getValidProperties(definitionName, definitions) {
+  const def = definitions[definitionName];
+  if (!def) return new Set();
+
+  if (def.properties) {
+    return new Set(Object.keys(def.properties));
+  }
+
+  if (def.oneOf) {
+    const allProps = new Set();
+    for (const entry of def.oneOf) {
+      const ref = entry.$ref;
+      if (ref && ref.startsWith("#/definitions/")) {
+        const refName = ref.slice("#/definitions/".length);
+        const refDef = definitions[refName];
+        if (refDef && refDef.properties) {
+          Object.keys(refDef.properties).forEach((p) => allProps.add(p));
+        }
+      }
+      if (entry.properties) {
+        Object.keys(entry.properties).forEach((p) => allProps.add(p));
+      }
+    }
+    return allProps;
+  }
+
+  return new Set();
+}
+
 // --- Formatting ---
 
 function formatDefinition(name, definition, compact) {
@@ -372,6 +431,52 @@ function validateYamlFile(filepath, definitions) {
     } else {
       console.log("[WARN] Missing settings.instructions — child agents need instructions for generative orchestration");
       warnings++;
+    }
+  }
+
+  // 3b. Schema-driven structural validation
+  if (kind && data.beginDialog && typeof data.beginDialog === "object") {
+    const bd = data.beginDialog;
+    const triggerKind = bd.kind;
+
+    // Check action kinds against valid DialogAction kinds from schema
+    if (Array.isArray(bd.actions)) {
+      const validActionKinds = getValidKindsFromOneOf("DialogAction", definitions);
+      if (validActionKinds.length > 0) {
+        for (const action of bd.actions) {
+          if (action && typeof action === "object" && action.kind) {
+            if (validActionKinds.includes(action.kind)) {
+              passes++;
+            } else {
+              console.log(
+                `[FAIL] '${action.kind}' is not a valid action kind inside beginDialog.actions ` +
+                `(not found in DialogAction schema definition). ` +
+                `Use 'schema-lookup.bundle.js resolve DialogAction' to see valid action kinds.`
+              );
+              failures++;
+            }
+          }
+        }
+      }
+    }
+
+    // Check for properties in beginDialog that belong at the root level instead
+    if (triggerKind) {
+      const triggerProps = getValidProperties(triggerKind, definitions);
+      const rootDef = definitions[kind];
+      const rootProps = rootDef && rootDef.properties ? new Set(Object.keys(rootDef.properties)) : new Set();
+
+      for (const key of Object.keys(bd)) {
+        if (key === "kind" || key === "id") continue;
+        if (!triggerProps.has(key) && rootProps.has(key)) {
+          console.log(
+            `[FAIL] '${key}' is inside beginDialog but belongs at the ${kind} root level ` +
+            `(not a valid property of ${triggerKind}, but is a property of ${kind}). ` +
+            `Move '${key}' to the top level of the YAML.`
+          );
+          failures++;
+        }
+      }
     }
   }
 

--- a/skills/new-topic/SKILL.md
+++ b/skills/new-topic/SKILL.md
@@ -2,7 +2,7 @@
 user-invocable: false
 description: Create a new Copilot Studio topic YAML file. Use when the user asks to create a new topic, conversation flow, or dialog for their agent.
 argument-hint: <topic description>
-allowed-tools: Bash(node *schema-lookup.bundle.js *), Read, Write, Glob
+allowed-tools: Bash(node *schema-lookup.bundle.js *), Bash(node *manage-agent.bundle.js *), Read, Write, Glob
 context: fork
 agent: copilot-studio-author
 ---
@@ -58,30 +58,63 @@ Generate a new Copilot Studio topic YAML file based on user requirements.
 7. **Save** to the agent's `topics/<topic-name>.topic.mcs.yml` directory
 
 8. **MANDATORY: Validate the generated file** after saving:
+
+   **Step A: Schema validation** — always run this first:
    ```bash
    node ${CLAUDE_SKILL_DIR}/../../scripts/schema-lookup.bundle.js validate <saved-file.yml>
    ```
-   If validation fails, fix the issues before reporting success to the user.
+
+   **Step B: LSP-based validation** — also run this if the agent has `.mcs/conn.json`:
+   Read `.mcs/conn.json` to get connection details, then:
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/../../scripts/manage-agent.bundle.js validate \
+     --workspace "<path-to-agent-folder>" \
+     --tenant-id "<tenantId>" \
+     --environment-id "<envId>" \
+     --environment-url "<envUrl>" \
+     --agent-mgmt-url "<mgmtUrl>"
+   ```
+
+   Both validations are complementary: schema validation checks structural correctness (action kinds, property placement), while LSP validation checks Power Fx expressions, cross-file references, and environment-specific rules. If either fails, fix the issues before reporting success to the user.
 
 ## Generative Orchestration Guidelines
 
 When the agent has `GenerativeActionsEnabled: true` in settings:
 
-**Use Topic Inputs** (AutomaticTaskInput) instead of Question nodes to auto-collect user info:
+**Use Topic Inputs** (AutomaticTaskInput) instead of Question nodes to auto-collect user info.
+Place `inputs` at the **AdaptiveDialog root level** (NOT inside `beginDialog`):
 ```yaml
-inputs:
+kind: AdaptiveDialog
+inputs:                    # <-- at AdaptiveDialog root, NOT inside beginDialog
   - kind: AutomaticTaskInput
     propertyName: userName
     description: "The user's name"
     entity: StringPrebuiltEntity
     shouldPromptUser: true
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  actions:
+    - ...
 ```
 - The orchestrator auto-collects inputs based on the description — no explicit Question node needed.
 - Still use Question nodes when: conditional asks (ask X only if Y), or end-of-flow confirmations.
 
-**Use Topic Outputs** instead of SendActivity for final results:
+**Use Topic Outputs** instead of SendActivity for final results.
+Use `outputType` at the root level and `SetVariable` to set output values — do NOT use `TaskOutput` (which is only valid in `TaskDialog` connector actions):
 ```yaml
-outputType:
+kind: AdaptiveDialog
+inputs:
+  - ...
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  actions:
+    - kind: SetVariable
+      id: setVar_abc123
+      variable: Topic.result
+      value: ="computed value"
+outputType:                # <-- at AdaptiveDialog root
   properties:
     result:
       displayName: result
@@ -91,7 +124,7 @@ outputType:
 - The orchestrator generates the user-facing message from outputs.
 - Do NOT use SendActivity to show final outputs (rare exceptions: precise mid-flow messages).
 
-**Include inputType/outputType schemas** when using inputs/outputs:
+**Include inputType/outputType schemas** at the AdaptiveDialog root level when using inputs/outputs:
 ```yaml
 inputType:
   properties:


### PR DESCRIPTION
## Summary

Fixes #76 — The new-topic skill generates YAML that causes kind undefined error in the Copilot Studio UI.

## Root Cause

Two structural issues in generated YAML:
1. inputs placed inside beginDialog instead of at the AdaptiveDialog root level
2. TaskOutput used as an action in beginDialog.actions — it's only valid in TaskDialog (connector actions)

## Changes

### Schema-driven validation (scripts/src/schema-lookup.js)

Added two schema-driven validation checks to validateYamlFile() — all rules are derived from the JSON schema, not hardcoded:

1. **Action kind validation**: Extracts valid DialogAction kinds from DialogAction.oneOf refs in the schema, then verifies all action kinds in beginDialog.actions against this list. Catches TaskOutput and any future invalid action kinds.

2. **Property placement validation**: For each property in beginDialog, checks if it's a valid property of the trigger kind's schema definition. If not, but it IS a valid property of the root kind (e.g. AdaptiveDialog), reports a FAIL with guidance to move it to root level. Catches inputs inside beginDialog.

### SKILL.md updates (skills/new-topic/SKILL.md)

- Added manage-agent.bundle.js to allowed-tools for LSP-based validation
- Updated step 8 to prefer LSP validation (via manage-agent.bundle.js validate) with schema validation fallback
- Updated generative orchestration examples to show correct structural placement of inputs and outputType at AdaptiveDialog root
- Added warning that TaskOutput is only valid in TaskDialog
- Marked arithmeticsum.topic.mcs.yml as canonical reference for input/output patterns

## Testing

Validated with broken YAML (both issues detected as FAIL):
- TaskOutput is not a valid action kind inside beginDialog.actions
- inputs is inside beginDialog but belongs at the AdaptiveDialog root level

Validated all existing templates pass (greeting, fallback, arithmeticsum, question-topic).