### PR TITLE
fix: use absolute plugin paths and VS Code-compatible hook output

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"var r=process.env.CLAUDE_PLUGIN_ROOT;if(r){var f=require('fs'),p=require('path');process.stdout.write(f.readFileSync(p.join(r,'hooks','system-prompt.md'),'utf8'))}\"",
+            "command": "node -e \"var r=process.env.CLAUDE_PLUGIN_ROOT;if(r){var f=require('fs'),p=require('path');var t=f.readFileSync(p.join(r,'hooks','system-prompt.md'),'utf8');process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'SessionStart',additionalContext:t}}))}\"",
             "bash": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/print-prompt.js\"",
             "powershell": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/print-prompt.js\""
           },


### PR DESCRIPTION
Follow-up to #103. Fixes two issues:

**1. Installed plugin path resolution**
Hooks used relative paths (\
ode hooks/print-prompt.js\) which resolved against the user's project cwd, not the plugin directory. Now uses \\\ absolute paths in bash/powershell keys.

**2. VS Code compatibility**
VS Code only uses the \command\ key (ignores \ash\/\powershell\), and expects SessionStart hooks to return JSON with \hookSpecificOutput.additionalContext\. Updated the command field to output this format.

**Runtime matrix:**
| Runtime | Key used | Output format |
|---------|----------|---------------|
| Claude Code | \command\ | \hookSpecificOutput\ JSON (captures raw stdout) |
| Copilot CLI | \ash\/\powershell\ | \dditionalContext\ JSON via print-prompt.js |
| VS Code | \command\ | \hookSpecificOutput\ JSON |

Removes the separate root \hooks.json\ — single \hooks/hooks.json\ serves all runtimes.