### PR TITLE
chore: bump version to 1.0.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "copilot-studio",
       "description": "Microsoft Copilot Studio YAML authoring toolkit. Create, edit, validate, and test Copilot Studio agents using YAML files.",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-studio",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Microsoft Copilot Studio YAML authoring toolkit. Create, edit, validate, and test Copilot Studio agents using YAML files.",
   "author": {
     "name": "Microsoft Copilot Studio CAT Team"


### PR DESCRIPTION
Bumps plugin version to 1.0.7 in both plugin.json and marketplace.json.