### PR TITLE
Add weekly release branch workflow

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -1,0 +1,86 @@
+name: Create weekly release branch
+
+on:
+  schedule:
+    # Every Wednesday at 09:00 UTC
+    - cron: "0 9 * * 3"
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: "Override the version (e.g. 1.1.0). Leave empty for automatic patch bump."
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Calculate release week
+        id: week
+        run: |
+          YEAR=$(date -u +%Y)
+          WEEK=$(date -u +%V)
+          RELEASE="release/${YEAR}-W${WEEK}"
+          echo "release_branch=$RELEASE" >> "$GITHUB_OUTPUT"
+          echo "Release branch: $RELEASE"
+
+      - name: Check if branch already exists
+        id: check
+        run: |
+          BRANCH="${{ steps.week.outputs.release_branch }}"
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Branch $BRANCH already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version and create branch
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          BRANCH="${{ steps.week.outputs.release_branch }}"
+
+          # Read current version
+          CURRENT=$(jq -r '.version' .claude-plugin/plugin.json)
+          echo "Current version: $CURRENT"
+
+          # Determine new version
+          if [ -n "${{ github.event.inputs.version_override }}" ]; then
+            NEW_VERSION="${{ github.event.inputs.version_override }}"
+          else
+            # Bump patch: 1.0.7 -> 1.0.8
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
+          echo "New version: $NEW_VERSION"
+
+          # Update both version files
+          jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
+          jq --arg v "$NEW_VERSION" '.plugins[0].version = $v' .claude-plugin/marketplace.json > tmp.json && mv tmp.json .claude-plugin/marketplace.json
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create branch, commit, and push
+          git checkout -b "$BRANCH"
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore: bump version to ${NEW_VERSION} for ${BRANCH}"
+          git push origin "$BRANCH"
+
+          # Summary
+          echo "### Release branch created :rocket:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Branch** | \`$BRANCH\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Version** | \`$CURRENT\` → \`$NEW_VERSION\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Next steps: create feature branches from \`$BRANCH\` and PR back into it." >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,31 @@ claude --plugin-dir /path/to/skills-for-copilot-studio
 claude plugin install /path/to/skills-for-copilot-studio --scope user
 ```
 
+## Release workflow
+
+The plugin follows a **weekly release branch** cadence. A new branch is created every Wednesday automatically via GitHub Actions.
+
+### How it works
+
+1. **Every Wednesday at 09:00 UTC**, the [`new-release`](.github/workflows/new-release.yml) workflow runs:
+   - Creates a `release/YYYY-WNN` branch from `main` (e.g., `release/2026-W16`)
+   - Bumps the patch version in `plugin.json` and `marketplace.json`
+   - Commits and pushes the branch
+
+2. **During the week**, fork feature branches from the release branch and PR back into it:
+   ```bash
+   git checkout release/2026-W16
+   git checkout -b feature/my-change
+   # ... make changes ...
+   # PR into release/2026-W16
+   ```
+
+3. **When ready to ship**, open a PR from `release/YYYY-WNN` into `main`.
+
+### Manual trigger
+
+You can also create a release branch on demand from the [Actions tab](../../actions/workflows/new-release.yml) using **Run workflow**. Optionally provide a version override (e.g., `1.1.0` for a minor bump).
+
 ## Rebuilding bundled scripts
 
 The plugin includes bundled Node.js scripts (schema lookup, chat-with-agent) built with [esbuild](https://esbuild.github.io/). Source is in `scripts/src/`, bundles are in `scripts/`.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/new-release.yml`) that creates a `release/YYYY-WNN` branch from `main` every Wednesday at 09:00 UTC
- Automatically bumps the patch version in `plugin.json` and `marketplace.json`
- Supports manual trigger via `workflow_dispatch` with optional version override
- Documents the release workflow in `CONTRIBUTING.md`

## Test plan
- [ ] Trigger the workflow manually via Actions tab > "Create weekly release branch" > Run workflow
- [ ] Verify the release branch is created with the bumped version in both JSON files
- [ ] Verify the workflow skips if the branch already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)