### PR TITLE
Move release branch cron to Thursday

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -2,8 +2,8 @@ name: Create weekly release branch
 
 on:
   schedule:
-    # Every Wednesday at 09:00 UTC
-    - cron: "0 9 * * 3"
+    # Every Thursday at 09:00 UTC (day after release merges to main)
+    - cron: "0 9 * * 4"
   workflow_dispatch:
     inputs:
       version_override:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ claude plugin install /path/to/skills-for-copilot-studio --scope user
 
 ## Release workflow
 
-The plugin follows a **weekly release branch** cadence. A new branch is created every Wednesday automatically via GitHub Actions.
+The plugin follows a **weekly release branch** cadence. Release branches are merged to `main` on Wednesdays, and a new branch is created every Thursday automatically via GitHub Actions.
 
 ### How it works
 
-1. **Every Wednesday at 09:00 UTC**, the [`new-release`](.github/workflows/new-release.yml) workflow runs:
+1. **Every Thursday at 09:00 UTC**, the [`new-release`](.github/workflows/new-release.yml) workflow runs:
    - Creates a `release/YYYY-WNN` branch from `main` (e.g., `release/2026-W16`)
    - Bumps the patch version in `plugin.json` and `marketplace.json`
    - Commits and pushes the branch


### PR DESCRIPTION
## Summary
- Shifts the weekly release branch creation from Wednesday to Thursday
- Release ships (merges to main) on Wednesday; new branch is created the next day so the team has Thu→Wed to work on it

## Test plan
- [ ] Verify cron is `0 9 * * 4` (Thursday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)