### PR TITLE
Add connection ID support for authenticated eval runs

### DIFF
--- a/scripts/eval-api.bundle.js
+++ b/scripts/eval-api.bundle.js
@@ -14901,7 +14901,8 @@ function parseArgs() {
     testsetId: null,
     runId: null,
     published: false,
-    runName: null
+    runName: null,
+    connectionId: null
   };
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
@@ -14931,6 +14932,9 @@ function parseArgs() {
         break;
       case "--run-name":
         parsed.runName = args[++i];
+        break;
+      case "--connection-id":
+        parsed.connectionId = args[++i];
         break;
       default:
         if (!args[i].startsWith("--") && !parsed.command) {
@@ -15092,9 +15096,13 @@ async function cmdStartRun(config, accessToken, args) {
   if (args.runName) {
     body.evaluationRunName = args.runName;
   }
+  if (args.connectionId) {
+    body.mcsConnectionId = args.connectionId;
+  }
   log(`POST ${url}`);
   log(`  runOnPublishedBot: ${args.published}`);
   if (args.runName) log(`  evaluationRunName: ${args.runName}`);
+  if (args.connectionId) log(`  mcsConnectionId: ${args.connectionId}`);
   const data = await ppApiRequest("POST", url, body, accessToken);
   process.stdout.write(JSON.stringify({
     status: "ok",

--- a/scripts/src/eval-api.js
+++ b/scripts/src/eval-api.js
@@ -21,6 +21,7 @@
  *   --run-id <id>            Evaluation run ID (required for get-run, get-results)
  *   --published              Test published bot (default: test draft)
  *   --run-name <name>        Custom display name for the evaluation run
+ *   --connection-id <id>     MCS connection ID for authenticated execution (knowledge sources / tools)
  *
  * Output: JSON on stdout, diagnostics on stderr.
  * Exit codes: 0 = success, 1 = error
@@ -53,6 +54,7 @@ function parseArgs() {
     runId: null,
     published: false,
     runName: null,
+    connectionId: null,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -83,6 +85,9 @@ function parseArgs() {
         break;
       case "--run-name":
         parsed.runName = args[++i];
+        break;
+      case "--connection-id":
+        parsed.connectionId = args[++i];
         break;
       default:
         if (!args[i].startsWith("--") && !parsed.command) {
@@ -294,10 +299,14 @@ async function cmdStartRun(config, accessToken, args) {
   if (args.runName) {
     body.evaluationRunName = args.runName;
   }
+  if (args.connectionId) {
+    body.mcsConnectionId = args.connectionId;
+  }
 
   log(`POST ${url}`);
   log(`  runOnPublishedBot: ${args.published}`);
   if (args.runName) log(`  evaluationRunName: ${args.runName}`);
+  if (args.connectionId) log(`  mcsConnectionId: ${args.connectionId}`);
 
   const data = await ppApiRequest("POST", url, body, accessToken);
 

--- a/skills/run-eval/SKILL.md
+++ b/skills/run-eval/SKILL.md
@@ -28,15 +28,36 @@ node ${CLAUDE_SKILL_DIR}/../../scripts/eval-api.bundle.js list-testsets --worksp
 - **One test set**: Tell the user which one you're using and proceed.
 - **Multiple test sets**: Show them all and ask the user to pick. Do not proceed until they answer.
 
-## Step 2: Start the run
+## Step 2: Ask about authenticated execution — MANDATORY, do not skip
+
+**You MUST ask this question and wait for the user's answer before starting the run.**
+
+Ask the user:
+
+> **Does your agent use authenticated knowledge sources or connector actions (tools) that require user identity?**
+> If so, you'll need to provide a connection ID — without it, the eval runs anonymously and **tools and knowledge sources will not be used**.
+>
+> **How to obtain the connection ID:**
+> 1. Go to https://make.powerautomate.com
+> 2. Open **Connections** from the side menu
+> 3. Select the relevant **Microsoft Copilot Studio** connection
+> 4. Copy the connection ID from the URL (the GUID segment after `/connections/`)
+>
+> If your agent doesn't use authenticated knowledge or tools, you can skip this.
+
+**Do not proceed to Step 3 until the user responds.**
+
+## Step 3: Start the run
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/../../scripts/eval-api.bundle.js start-run --workspace <path> --client-id <id> --testset-id <id> --run-name "Draft eval <date>"
 ```
 
+Add `--connection-id <id>` if the user provided a connection ID in Step 2.
+
 Add `--published` only if the user explicitly asked for published-bot testing.
 
-## Step 3: Poll until complete
+## Step 4: Poll until complete
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/../../scripts/eval-api.bundle.js get-run --workspace <path> --client-id <id> --run-id <runId>
@@ -46,7 +67,7 @@ Poll every 15-30 seconds. Report progress: "Processing: 3/10 test cases..."
 
 Stop when `state` is `Completed`, `Failed`, `Abandoned`, or `Cancelled`.
 
-## Step 4: Fetch and analyze results
+## Step 5: Fetch and analyze results
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/../../scripts/eval-api.bundle.js get-results --workspace <path> --client-id <id> --run-id <runId>
@@ -61,8 +82,8 @@ Present a summary table (total, passed, failed, errors). For failures:
 | `CapabilityUse` Fail | `missingInvocationSteps` |
 | `Error` status | `errorReason` — often a test set config issue, not a YAML issue |
 
-## Step 5: Propose fixes (if failures found)
+## Step 6: Propose fixes (if failures found)
 
 For YAML authoring failures: find the relevant topic, read it, propose specific edits. Wait for user approval before applying.
 
-After applying: offer to push and re-run (go back to Step 2).
+After applying: offer to push and re-run (go back to Step 3).


### PR DESCRIPTION
## Summary
- Adds `--connection-id` flag to `eval-api.js`, passed as `mcsConnectionId` in the start-run API request body
- Adds mandatory Step 2 in `run-eval` skill that asks users about authenticated execution and explains how to find the connection ID at make.powerautomate.com > Connections
- Without a connection ID, evals run anonymously and authenticated knowledge sources / tools are skipped

## Test plan
- [x] Ran eval without connection ID — 90% pass rate, tools/knowledge ran anonymously
- [x] Ran eval with connection ID (`shared-microsoftcopi-9fcb7551-5cc6-4c83-a881-e1993c15b7db`) — confirmed `mcsConnectionId` sent in POST body

🤖 Generated with [Claude Code](https://claude.com/claude-code)