### PR TITLE
Fix release branch creation to target next week

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -25,11 +25,14 @@ jobs:
       - name: Calculate release week
         id: week
         run: |
-          YEAR=$(date -u +%Y)
-          WEEK=$(date -u +%V)
+          # Use +7 days so Thursday (day after release) targets next week's branch.
+          # Use %G/%V (ISO year/week) to handle year boundaries correctly.
+          FUTURE=$(date -u -d "+7 days" +%Y-%m-%d)
+          YEAR=$(date -u -d "$FUTURE" +%G)
+          WEEK=$(date -u -d "$FUTURE" +%V)
           RELEASE="release/${YEAR}-W${WEEK}"
           echo "release_branch=$RELEASE" >> "$GITHUB_OUTPUT"
-          echo "Release branch: $RELEASE"
+          echo "Release branch: $RELEASE (computed from $FUTURE)"
 
       - name: Check if branch already exists
         id: check


### PR DESCRIPTION
## Summary
- Fixes the `new-release.yml` workflow week calculation to target **next week's** branch
- The workflow runs Thursday but Thursday is still the same ISO week as Wednesday's release, so it was recreating the current week's branch instead of the next one
- Uses `date -d "+7 days"` to compute next week's ISO year (`%G`) and week (`%V`)
- Also fixes a potential year-boundary bug (`%Y` → `%G` for ISO year)

## What was happening
- Wednesday: release W16 to main
- Thursday: workflow runs, computes W16, finds branch exists, skips (or overwrites)

## What should happen
- Wednesday: release W16 to main
- Thursday: workflow runs, computes W17, creates new branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)