### PR TITLE
feat: OpenAPI HTTP API tools, NL-to-query compilation, and data visualization

### DIFF
--- a/skills/authoring-tips/SKILL.md
+++ b/skills/authoring-tips/SKILL.md
@@ -39,3 +39,23 @@ Prevents child agents (connected agents) from sending messages directly to the u
 - The user wants a child agent to return data without messaging the user
 - The user is confused about the completion setting on a child agent
 - The parent agent needs to control all user-facing responses
+
+## OpenAPI HTTP API Tools → [openapi-http-api-tools.md](openapi-http-api-tools.md)
+
+Writing OpenAPI specs for public HTTP/REST APIs and uploading them as plugin tools. Covers spec authoring rules (response `type: object`, format defaults), the upload "Add input" parameter gotcha, and common runtime errors.
+
+**Read this tip when:**
+- The user is writing an OpenAPI spec for a public REST API
+- A plugin tool upload fails or returns errors at runtime
+- The user gets `JsonReaderException`, `Expecting Record but received Table`, or missing parameters
+- The user asks about the difference between OpenAPI plugin tools and connector actions
+
+## Data Visualization → [data-visualization.md](data-visualization.md)
+
+Options for showing charts, diagrams, and structured data in agent responses: QuickChart.io (Chart.js charts via URL), Mermaid.ink (diagrams via URL), and Adaptive Cards (native tables and layouts).
+
+**Read this tip when:**
+- The user wants to display charts or graphs in agent responses
+- An API returns binary data (images, PDFs) that can't be a plugin tool
+- The user asks about QuickChart, Mermaid, or Adaptive Cards in Copilot Studio
+- The user needs to visualize data from API tool calls

--- a/skills/authoring-tips/data-visualization.md
+++ b/skills/authoring-tips/data-visualization.md
@@ -1,0 +1,115 @@
+# Data Visualization in Chat — Authoring Tip
+
+How to display charts, diagrams, and visual data in Copilot Studio agent responses when the platform only supports text and image rendering — no native charting widget exists.
+
+## The Problem
+
+Copilot Studio plugin tools expect JSON responses. APIs that return binary data (images, PDFs, chart images) cannot be used as OpenAPI tools — the response can't be parsed or displayed. But agents that work with data often need to show visual summaries.
+
+## The Solution: URL-Based Image Rendering
+
+Copilot Studio chat supports markdown image syntax: `![alt text](url)`. Services that render visual content from URL parameters can be used without a tool call — the agent constructs the URL in its response text, and the chat client renders it inline.
+
+### Option A: QuickChart.io (Chart.js via URL)
+
+[QuickChart.io](https://quickchart.io) renders Chart.js charts as PNG images. The chart configuration goes in the `c` query parameter as URL-encoded JSON.
+
+Add to agent instructions (`settings.mcs.yml`):
+
+```
+## Charts
+When the user asks for a chart or when data visualization would aid understanding:
+1. Gather data from the relevant API tool(s)
+2. Build a QuickChart URL: https://quickchart.io/chart?c={CHART_CONFIG}
+3. URL-encode the chart config JSON
+4. Display using markdown: ![Chart description](URL)
+
+Chart config example (Chart.js):
+{"type":"line","data":{"labels":["2022","2023","2024"],"datasets":[{"label":"GDP Growth %","data":[1.0,2.5,3.2]}]}}
+
+Supported types: line, bar, pie, doughnut, radar, scatter.
+Use clear axis labels, include units, and title the chart descriptively.
+```
+
+**Pros:** Wide chart type support, Chart.js ecosystem, no auth needed.
+**Cons:** URL length limit (~2000 chars) constrains dataset size. External dependency.
+
+### Option B: Mermaid.ink (Diagrams via URL)
+
+[Mermaid.ink](https://mermaid.ink) renders Mermaid diagram syntax as images. The diagram definition is base64-encoded in the URL path.
+
+Add to agent instructions:
+
+```
+## Diagrams
+When a process flow, timeline, or comparison diagram would help:
+1. Write the diagram in Mermaid syntax
+2. Base64-encode it
+3. Display: ![Diagram](https://mermaid.ink/img/{base64_encoded_mermaid})
+
+Example Mermaid (before encoding):
+graph LR
+  A[User Question] --> B[Orchestrator]
+  B --> C[API Tool]
+  C --> D[Response]
+```
+
+**Pros:** Flowcharts, sequence diagrams, Gantt charts, pie charts, timelines. Good for architectural or process visuals.
+**Cons:** Not suited for data-heavy charts. Base64 encoding adds complexity.
+
+### Option C: Adaptive Cards with Data (Native)
+
+Copilot Studio supports [Adaptive Cards](https://adaptivecards.io/) via `SendActivity` with `attachments`. Unlike the URL-based options, this is a native platform feature — no external service dependency.
+
+Adaptive Cards can display structured data as tables, fact sets, and formatted layouts. They don't have a native chart widget, but they excel at tabular and card-style data presentation.
+
+```yaml
+- kind: SendActivity
+  id: sendCard_x7Kp2m
+  activity:
+    attachments:
+      - kind: AdaptiveCardTemplate
+        cardContent: |
+          {
+            "type": "AdaptiveCard",
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5",
+            "body": [
+              {
+                "type": "TextBlock",
+                "text": "ECB Interest Rates",
+                "weight": "Bolder",
+                "size": "Medium"
+              },
+              {
+                "type": "FactSet",
+                "facts": [
+                  { "title": "Main Refi Rate", "value": "4.50%" },
+                  { "title": "Deposit Facility", "value": "4.00%" },
+                  { "title": "As of", "value": "2024-03" }
+                ]
+              }
+            ]
+          }
+```
+
+**Pros:** Native — no external dependency, no URL length limits, works offline, interactive elements possible.
+**Cons:** No chart rendering (bar/line/pie). Best for tables, summaries, and structured layouts.
+
+## Choosing an Approach
+
+| Need | Best option |
+|------|-------------|
+| Line, bar, pie charts from data | **QuickChart.io** — widest chart support |
+| Process flows, timelines, architecture diagrams | **Mermaid.ink** — purpose-built for diagrams |
+| Tabular data, KPI cards, structured summaries | **Adaptive Cards** — native, no dependency |
+| Combining chart + table in one response | QuickChart image + Adaptive Card table |
+
+You can mix approaches in one agent — use QuickChart for charts from API data and Adaptive Cards for structured summaries.
+
+## Limitations (All URL-Based Options)
+
+- **URL length limits** (~2000 chars for some clients) — keep datasets small or aggregate data points before charting
+- **Static images** — no hover, zoom, or click interactivity
+- **External dependency** — requires the chart/diagram service to be network-accessible from the user's client
+- **Not a tool call** — the agent constructs the URL in its response text; there's no tool output to process further

--- a/skills/authoring-tips/openapi-http-api-tools.md
+++ b/skills/authoring-tips/openapi-http-api-tools.md
@@ -1,0 +1,107 @@
+# OpenAPI HTTP API Tools — Authoring Tip
+
+Writing OpenAPI specs for public HTTP/REST APIs and uploading them as plugin tools via "Add tool → Upload specification" in Copilot Studio. Covers spec authoring rules, the upload parameter gotcha, and common runtime errors.
+
+> **Related skills:** Use `add-action` for the upload UI walkthrough, `edit-action` to modify action YAML after cloning, and `clone-agent` to get files locally. This tip covers what those skills don't: how to write specs that survive the upload and runtime pipeline.
+
+## The Problem
+
+OpenAPI specs that work fine with Swagger UI or Postman can fail silently in Copilot Studio — at upload time, at runtime, or both. The failures are non-obvious because they stem from platform-specific constraints (PowerFx type system, XML default responses, parameter registration).
+
+## Test the API Before Writing a Spec
+
+Call each endpoint manually first:
+
+```powershell
+Invoke-RestMethod "https://api.example.com/data?param=value&format=json"
+```
+
+| Check | Why |
+|-------|-----|
+| **JSON output** | Many institutional APIs (Eurostat, ECB, OECD) default to XML. If the API can return XML, add a `format` query param with a JSON default value in the spec. Without it, Copilot Studio gets XML and throws `JsonReaderException '<' is invalid`. |
+| **Response shape** | If the top-level JSON response is an array `[...]` instead of an object `{...}`, PowerFx crashes with *"Expecting Record but received a Table"*. The spec must declare `type: object` regardless of actual shape. |
+| **URL pattern** | SDMX-style APIs enforce strict dimension order in path params (e.g., `freq.unit.coicop.geo`). Wrong order returns 400 or empty results. Test with exact dimension order. |
+| **Required params** | Which query params are mandatory? Which have API-specific defaults you shouldn't rely on? |
+
+## Spec Rules for Copilot Studio
+
+### Minimum working spec
+
+```yaml
+openapi: "3.0.0"
+info:
+  title: My API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /data/{param}:
+    get:
+      operationId: getData
+      summary: Short summary
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Brief description
+        - name: format
+          in: query
+          required: true
+          schema:
+            type: string
+            default: JSON
+          description: Response format
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+```
+
+### Key rules
+
+1. **Response schema: always `type: object`** — even if the API actually returns an array. The orchestrator still parses correctly; PowerFx won't crash.
+
+2. **Force JSON with defaults** — if the API can return XML:
+   ```yaml
+   - name: format
+     in: query
+     required: true
+     schema:
+       type: string
+       default: JSON
+   ```
+
+3. **Keep descriptions short at upload time** — long descriptions or special characters cause *"Something went wrong"* on save. Enrich descriptions later via `modelDescription` in the cloned action file (use `edit-action`).
+
+4. **Use `default` for fixed params** — params that should always have the same value (e.g., `per_page: 500`).
+
+5. **Response schema can be minimal** — a bare `type: object` is sufficient. You don't need to describe every field.
+
+6. **Omit `security`/`securitySchemes` for no-auth APIs** — set auth to "None" during upload instead.
+
+## Upload Parameter Gotcha
+
+When uploading via "Add tool → Upload specification", in the **"Select tool parameters"** step:
+
+- Parameters are **NOT pre-selected**
+- You must click **"Add input"** for EVERY available parameter (path params + query params)
+- Only explicitly added params become `AutomaticTaskInput` in the generated action YAML
+- If you skip this, the orchestrator cannot pass values to those parameters at runtime
+
+This is the single most common cause of "my tool ignores the parameters I pass." Re-upload and add all inputs.
+
+## Common Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `JsonReaderException '<' is invalid` | API returned XML, not JSON | Add `format` query param with JSON default in spec |
+| `Expecting Record but received Table` | Response is a top-level JSON array | Change response schema to `type: object` |
+| "Something went wrong" on save | Long descriptions, special characters, or complex schema | Shorten descriptions, simplify schema |
+| Tool ignores parameter values | Didn't click "Add input" during upload | Re-upload, click "Add input" for all params |
+| 404 at runtime | Path params don't match actual API URL | Test URL manually, fix path in spec |
+| Tool missing from `actions/` after pull | Pull can't create new files | Use clone instead of pull (see `clone-agent`) |

--- a/skills/patterns/SKILL.md
+++ b/skills/patterns/SKILL.md
@@ -39,6 +39,16 @@ Uses `AutomaticTaskInput` to let the orchestrator's LLM classify or extract stru
 - The user wants to classify user intent without an explicit question or AI Prompt
 - The user asks about `AutomaticTaskInput`, `shouldPromptUser`, or orchestrator-generated inputs
 
+## NL → Query Compilation → [nl-to-query-compilation.md](nl-to-query-compilation.md)
+
+Teaches the orchestrator to translate natural language into structured API parameters by embedding glossaries in `modelDescription`. Maps user terms like "refi rate" to API codes like `B.U2.EUR.4F.KR.MRR_FR.LEV` — no custom model, no topic-level code.
+
+**Read this pattern when:**
+- API tools use codes, IDs, or structured query syntax the user shouldn't need to know
+- The orchestrator is passing wrong parameter values to an API tool
+- The user needs a glossary mapping natural language to API values
+- The user asks where API mappings belong (modelDescription vs agent instructions)
+
 ## Combining Patterns
 
 You can combine more than one pattern. For example, when using both glossary and user context, merge them into a **single** `conversation-init` topic rather than creating separate OnActivity topics. Use the template at `${CLAUDE_SKILL_DIR}/../../templates/topics/conversation-init.topic.mcs.yml`. The individual files explain the details.

--- a/skills/patterns/nl-to-query-compilation.md
+++ b/skills/patterns/nl-to-query-compilation.md
@@ -1,0 +1,79 @@
+# NL → Query Compilation — Pattern
+
+Teaches the generative orchestrator to translate natural language into structured API parameters by embedding glossaries in `modelDescription`. No custom model training, no topic-level code — the orchestrator does NL→Query on the fly at plan time.
+
+## The Problem
+
+Structured APIs use codes, IDs, and dimension keys that users don't know:
+
+- SDMX: `B.U2.EUR.4F.KR.MRR_FR.LEV` → "ECB main refinancing rate"
+- REST: `indicator=NY.GDP.MKTP.KD.ZG` → "GDP growth"
+- Filters: `coicop=CP00&unit=RCH_A` → "headline inflation, annual rate of change"
+
+Users say "What's the ECB refi rate?" — the orchestrator needs to map that to correct API parameters without asking the user for codes.
+
+## The Solution
+
+Put mapping glossaries in each tool's `modelDescription` field. The orchestrator reads `modelDescription` at plan time when deciding which tool to call and what values to pass to `AutomaticTaskInput` parameters.
+
+Edit `modelDescription` via `edit-action` after cloning the agent locally.
+
+### Glossary Format
+
+```
+GLOSSARY: "[user term]"/"[alias]"->[paramName]=[value]. "[user term]"->[param]=[value] [param2]=[value2]. [paramName]=FORMAT_HINT. [fixedParam]=[default].
+```
+
+### Example
+
+```yaml
+modelDescription: Retrieves ECB monetary and exchange rate data via SDMX. GLOSSARY: "refi rate"/"MRR"/"main refinancing rate"->flowRef=FM key=B.U2.EUR.4F.KR.MRR_FR.LEV. "deposit rate"/"DFR"->flowRef=FM key=B.U2.EUR.4F.KR.DFR.LEV. "marginal lending"/"MLF"->flowRef=FM key=B.U2.EUR.4F.KR.MLF_FR.LEV. "EUR/USD"/"euro dollar"->flowRef=EXR key=D.USD.EUR.SP00.A. startPeriod/endPeriod=YYYY-MM. format=jsondata.
+```
+
+### Rules
+
+1. **Map user terms (left) to API values (right)** — include common synonyms and abbreviations with `/` separators
+2. **Include the parameter name** each value goes into (e.g., `flowRef=FM`)
+3. **Group multi-param mappings** — when one user term requires multiple params, list them together (e.g., `flowRef=FM key=B.U2...`)
+4. **Include format hints** — `YYYY-MM`, `YYYY`, `ISO-8601` for date/time params
+5. **Include fixed defaults** — params that should always be the same (e.g., `format=jsondata`)
+6. **Keep it as one inline string** — do NOT use YAML block scalars (`>` or `|`). Multi-line `modelDescription` has been reported to break tool registration after push.
+
+## Where Things Belong
+
+This pattern complements agent instructions — they have different jobs:
+
+| Content | Where |
+|---------|-------|
+| API parameter mappings, glossaries, dimension codes | `modelDescription` on the action file |
+| Persona, tone, output format, date defaults | Agent instructions (`settings.mcs.yml`) |
+| Cross-tool orchestration, follow-up suggestions | Agent instructions |
+
+**Do NOT duplicate.** If a mapping is in `modelDescription`, don't repeat it in agent instructions. This avoids conflicts and keeps instructions clean for persona-level concerns.
+
+## Compilation Visibility
+
+Optionally add to agent instructions so users can see the NL→Query translation step:
+
+```
+Before executing an API call, briefly state the query parameters you will use
+so the user can see the NL → Query compilation step.
+```
+
+This builds user trust and helps debug incorrect mappings — the user sees what the agent interpreted and can correct it.
+
+## Multi-Tool Agents
+
+When an agent has multiple API tools, each tool's `modelDescription` should be self-contained. The orchestrator decides which tool to call based on the description, then uses that specific tool's glossary for parameter mapping.
+
+Don't create cross-tool glossaries in agent instructions. Each tool should independently describe what it covers and how to map user language to its parameters.
+
+## Debugging
+
+If the orchestrator passes wrong parameters:
+
+1. **Check the glossary** — is the mapping entry present in `modelDescription`?
+2. **Check input descriptions** — does the `description` on the `AutomaticTaskInput` explain the expected format?
+3. **Test the API** — does the correct parameter combination actually return data?
+4. **Add more aliases** — users may use terms not covered by current synonyms
+5. **Use compilation visibility** — ask the agent what parameters it chose, then fix the glossary entry

--- a/skills/patterns/nl-to-query-compilation.md
+++ b/skills/patterns/nl-to-query-compilation.md
@@ -1,30 +1,62 @@
 # NL → Query Compilation — Pattern
 
-Teaches the generative orchestrator to translate natural language into structured API parameters by embedding glossaries in `modelDescription`. No custom model training, no topic-level code — the orchestrator does NL→Query on the fly at plan time.
+Teaches the generative orchestrator to translate natural language into structured API parameters by enriching `modelDescription` with field descriptions, filter guidance, and code glossaries. No custom model training, no topic-level code — the orchestrator does NL→Query on the fly at plan time.
+
+## When to Use This
+
+**Every API tool benefits from an enriched `modelDescription`.** The default description from an OpenAPI spec upload is usually just the `summary` — not enough for the orchestrator to understand what each field means, what values are valid, or how to filter results. At minimum, describe what the API returns, what each parameter controls, and what values to use.
+
+The pattern scales from light to heavy depending on the API:
+
+| API type | What to put in modelDescription |
+|----------|-------------------------------|
+| **Simple REST** (free-text search, obvious params) | What the API does, what each param means, expected formats (`YYYY-MM-DD`) |
+| **Enum-heavy APIs** (status codes, category filters) | Field descriptions + valid enum values with human-readable labels |
+| **Coded/SDMX APIs** (opaque dimension keys, indicator codes) | Full glossary mapping user terms to API codes |
 
 ## The Problem
 
-Structured APIs use codes, IDs, and dimension keys that users don't know:
+The orchestrator picks tools and fills parameters using `modelDescription` and input `description` fields. Without enrichment:
+
+- It doesn't know what fields exist or what they mean
+- It can't map user language to the right filter values
+- It falls back to guessing parameter values — often wrong
+
+This is worst with APIs that use opaque codes:
 
 - SDMX: `B.U2.EUR.4F.KR.MRR_FR.LEV` → "ECB main refinancing rate"
 - REST: `indicator=NY.GDP.MKTP.KD.ZG` → "GDP growth"
 - Filters: `coicop=CP00&unit=RCH_A` → "headline inflation, annual rate of change"
 
-Users say "What's the ECB refi rate?" — the orchestrator needs to map that to correct API parameters without asking the user for codes.
+But even straightforward APIs suffer — if the orchestrator doesn't know that `status` accepts `active|archived|draft`, it will guess or omit the parameter entirely.
 
 ## The Solution
 
-Put mapping glossaries in each tool's `modelDescription` field. The orchestrator reads `modelDescription` at plan time when deciding which tool to call and what values to pass to `AutomaticTaskInput` parameters.
+Enrich each tool's `modelDescription` with field descriptions, filter guidance, and — for coded APIs — explicit glossaries that map user terms to API values. The orchestrator reads `modelDescription` at plan time when deciding which tool to call and what values to pass to `AutomaticTaskInput` parameters.
 
 Edit `modelDescription` via `edit-action` after cloning the agent locally.
 
-### Glossary Format
+### Levels of Enrichment
+
+**Light** — describe what the API does and what each param means:
+```yaml
+modelDescription: Searches the product catalog. 'category' filters by product category (electronics, clothing, home, sports). 'sort' orders results (price-asc, price-desc, rating, newest). 'q' is free-text search. 'inStock' is true/false.
+```
+
+**Medium** — add enum values with human labels:
+```yaml
+modelDescription: Retrieves HR policy documents. 'region' accepts NA (North America), EMEA (Europe/Middle East/Africa), APAC (Asia-Pacific). 'policyType' accepts wfh (work from home), travel, benefits, leave. 'effectiveDate' in YYYY-MM-DD.
+```
+
+**Full glossary** — map user terms to opaque codes:
+
+### Glossary Format (for coded APIs)
 
 ```
 GLOSSARY: "[user term]"/"[alias]"->[paramName]=[value]. "[user term]"->[param]=[value] [param2]=[value2]. [paramName]=FORMAT_HINT. [fixedParam]=[default].
 ```
 
-### Example
+### Full Glossary Example
 
 ```yaml
 modelDescription: Retrieves ECB monetary and exchange rate data via SDMX. GLOSSARY: "refi rate"/"MRR"/"main refinancing rate"->flowRef=FM key=B.U2.EUR.4F.KR.MRR_FR.LEV. "deposit rate"/"DFR"->flowRef=FM key=B.U2.EUR.4F.KR.DFR.LEV. "marginal lending"/"MLF"->flowRef=FM key=B.U2.EUR.4F.KR.MLF_FR.LEV. "EUR/USD"/"euro dollar"->flowRef=EXR key=D.USD.EUR.SP00.A. startPeriod/endPeriod=YYYY-MM. format=jsondata.


### PR DESCRIPTION
## Summary  Three new contributions from building a macro-economic analyst agent with public HTTP APIs (ECB, Eurostat, World Bank):  ### Authoring Tips (2 new files)  **OpenAPI HTTP API Tools** (skills/authoring-tips/openapi-http-api-tools.md) - OpenAPI spec authoring rules specific to Copilot Studio (response \	ype: object\ for top-level arrays, format defaults for XML APIs) - The upload 'Add input' parameter gotcha (params not pre-selected) - Common runtime errors and fixes (JsonReaderException, PowerFx array crash) - Complements existing \dd-action\ and \dit-action\ skills without duplicating them  **Data Visualization** (skills/authoring-tips/data-visualization.md) - Three options for charts/diagrams in agent responses: QuickChart.io, Mermaid.ink, Adaptive Cards - Comparison table for choosing the right approach - URL construction pattern for binary response workaround  ### Patterns (1 new file)  **NL → Query Compilation** (skills/patterns/nl-to-query-compilation.md) - Glossary format for \modelDescription\ that maps natural language to structured API parameters - Separation of concerns: glossaries in modelDescription vs persona in agent instructions - Compilation visibility pattern for user trust - Multi-tool agent guidance  ### Index updates - Added entries to \skills/authoring-tips/SKILL.md\ and \skills/patterns/SKILL.md\ following existing format