### PR TITLE
Add 6 new Authoring tips and 2 new Patterns

### DIFF
--- a/skills/authoring-tips/SKILL.md
+++ b/skills/authoring-tips/SKILL.md
@@ -1,7 +1,7 @@
 ---
 user-invocable: false
 name: authoring-tips
-description: "Index of practical authoring tips and workarounds for Copilot Studio agents. When a request may need best-practice guidance, an authoring technique, or a workaround for improving an agent's behavior, retrieve this index before deciding what detailed guidance is relevant. Do not decide from this frontmatter alone; use the index summaries, then open only the specific tip file if needed. Do not use for repeatable implementation patterns, general knowledge sources, or topic creation."
+description: "Index of practical authoring tips and workarounds for Copilot Studio agents. When a request may need best-practice guidance, an authoring technique, or a workaround for improving an agent's behavior, retrieve this index before deciding what detailed guidance is relevant. Do not decide from this frontmatter alone; use the index summaries, then open only the specific tip file if needed. Do not use for repeatable implementation patterns, general knowledge sources, or topic creation. USE FOR: date context, Today(), DateTimeFormat, Switch, BeginDialog, dynamic redirect, child agent, SendMessageTool, output variables, connected agents, completion setting, OnError, ContentFiltered, Azure OpenAI, RAI subcodes, OpenAIViolence, OpenAIHate, OpenAISexual, OpenAISelfHarm, OpenAIJailBreak, OpenAIndirectAttack, content filter, line breaks, <br />, paragraph spacing, wall of text, SendActivity formatting, Question node formatting, OnKnowledgeRequested, hold message, typing indicator, knowledge search latency, random message, Power Fx Table, MCP server, MCP tool, deterministic tool call, forced tool invocation, child agent intent routing, chain of thought, CoT, thinking messages, AutomaticTaskInput, modelDescription, reasoning trace, conversation history, transcript, Recognize intent, ConversationHistory, escalation, live agent handoff."
 context: fork
 agent: copilot-studio-author
 ---
@@ -39,3 +39,64 @@ Prevents child agents (connected agents) from sending messages directly to the u
 - The user wants a child agent to return data without messaging the user
 - The user is confused about the completion setting on a child agent
 - The parent agent needs to control all user-facing responses
+
+## RAI Error Handling in OnError → [rai-error-handling.md](rai-error-handling.md)
+
+Catches Azure OpenAI Responsible AI content-filter errors in the `OnError` topic, classifies them by subcode (`OpenAIViolence`, `OpenAIHate`, `OpenAISexual`, `OpenAISelfHarm`, `OpenAIJailBreak`, `OpenAIndirectAttack`) via an AI Builder prompt, and delivers category-specific messages instead of a generic error.
+
+**Read this tip when:**
+- The user needs industry-specific or empathetic RAI error messages (healthcare, education, government)
+- The user wants category-specific handling (e.g., crisis resources for self-harm, security notifications for jailbreak attempts)
+- The user needs telemetry on which filter categories are triggering
+- The user asks about `OnError`, `ContentFiltered`, Azure OpenAI content filters, or RAI subcodes
+
+## Line Breaks in Messages → [line-breaks-in-messages.md](line-breaks-in-messages.md)
+
+Inserts `<br /><br />` inside `SendActivity` and `Question` node `activity`/`prompt` fields to render consistent paragraph spacing across Teams, web chat, and other channels. Plain YAML newlines render as spaces in most channels.
+
+**Read this tip when:**
+- The user reports long messages feel like walls of text
+- Multi-part questions or welcome messages need visual separation
+- The user wants consistent paragraph spacing across channels
+- The user asks about line breaks, `<br />`, or formatting in messages/questions
+
+## Hold Message During Knowledge Search → [knowledge-hold-message.md](knowledge-hold-message.md)
+
+Sends a randomized "please hold" message during knowledge search via a custom `OnKnowledgeRequested` topic. Uses an inline Power Fx `Table()` of ~40 messages and `Rand()/Index()` for random selection — no connector calls, runs in milliseconds.
+
+**Read this tip when:**
+- The user's agent has noticeable knowledge-search latency
+- The user wants to avoid silent wait times during retrieval
+- Users are abandoning conversations or resending questions during delays
+- The user asks about `OnKnowledgeRequested`, typing indicators, or hold messages
+
+## Deterministic MCP Server Tool Calls → [deterministic-mcp-calls.md](deterministic-mcp-calls.md)
+
+Two workarounds for forcing MCP server tools to fire reliably for a specific intent: (1) name the tool explicitly in agent instructions, or (2) wrap the tool in a dedicated child agent with trigger phrases. Covers the current platform limitations (no `/` syntax, no MCP nodes in topics).
+
+**Read this tip when:**
+- An MCP tool must fire every time for a specific intent (compliance, data accuracy)
+- The user observes the orchestrator skipping an MCP tool
+- The user asks about `/` syntax with MCP tools, MCP tools in topics, or forcing tool invocation
+- The user needs to guarantee MCP tool calls for business-critical workflows
+
+## Chain of Thought (CoT) Logging → [chain-of-thought-logging.md](chain-of-thought-logging.md)
+
+Surfaces the orchestrator's intermediate reasoning as italicized "Thinking: …" chat messages during multi-step, multi-tool, or multi-agent orchestration. Uses an `AutomaticTaskInput` whose description doubles as an instruction telling the orchestrator what to log.
+
+**Read this tip when:**
+- The agent uses multiple tools, MCP servers, or child agents that chain together
+- Users experience 10–30s silences during multi-step reasoning
+- The user wants a debug/observability tool to trace orchestrator behavior
+- The agent uses reasoning models (GPT-5 Reasoning, Claude Opus) with long thinking times
+- The user asks about streaming, typing indicators, or progress messages for complex flows
+
+## Conversation History as a Variable → [conversation-history-variable.md](conversation-history-variable.md)
+
+Captures the conversation transcript at runtime via an `AutomaticTaskInput` whose description tells the orchestrator to dump the full history. Enables summarization, live-agent handoff, ticket attachments, email recaps, or passing context to downstream tools.
+
+**Read this tip when:**
+- The user needs to capture conversation context for live-agent escalation
+- A downstream tool/connector requires conversation history as input
+- The user wants to log conversations to Dataverse, a ticketing system, or email
+- The user asks about saving, exporting, or accessing the conversation transcript at runtime

--- a/skills/authoring-tips/chain-of-thought-logging.md
+++ b/skills/authoring-tips/chain-of-thought-logging.md
@@ -1,0 +1,96 @@
+# Chain of Thought (CoT) Logging
+
+Surface the orchestrator's intermediate reasoning as italicized "Thinking: …" chat messages during multi-step, multi-tool, or multi-agent orchestration. Gives users a real-time trace of what the agent is doing and why, instead of 10–30s of silence while tool chains run.
+
+> **For pure knowledge agents** (simple search-and-summarize), use the [Hold Message During Knowledge Search](knowledge-hold-message.md) tip instead. CoT logging is designed for agents with complex multi-step orchestration.
+
+## When to Use This Pattern
+
+- Your agent uses multiple tools, MCP servers, or child agents that chain together
+- Users experience long waits during multi-step reasoning with no feedback
+- You need a debug/observability tool to see what the orchestrator is doing step by step
+- The agent uses reasoning models (GPT-5 Reasoning, Claude Opus) where extended thinking creates long silences
+
+## When NOT to Use
+
+- **Pure knowledge agents** — use the knowledge hold message instead
+- **Simple single-turn Q&A** — the extra orchestrator calls aren't justified
+- **Cost-sensitive deployments** — each log adds Copilot credit consumption
+
+## How It Works
+
+The orchestrator reads an input variable's `description` to decide what data to pass in, so the **description doubles as an instruction to the model**. A lightweight "logger" topic accepts a CoT string via `AutomaticTaskInput`, then sends it as an italicized message.
+
+For non-reasoning models (GPT-4.1, GPT-5 Chat), this elicits chain-of-thought that you wouldn't otherwise see. For reasoning models, the orchestrator self-narrates rather than exposing the raw internal trace — the end-user experience is the same.
+
+> **Tested with:** GPT-4.1, GPT-5 Chat, GPT-5 Auto, GPT-5 Reasoning, Claude Sonnet, Claude Opus.
+
+### How It Looks
+
+```
+User: "What's the latest status on Project Alpha?"
+Agent: _Thinking: Looking up Project Alpha in the project tracker..._
+Agent: _Thinking: Found 3 recent updates. Checking team assignments..._
+Agent: _Thinking: Cross-referencing with the deadline calendar..._
+Agent: Here's the latest on Project Alpha: <final answer>
+```
+
+## YAML Example
+
+Create a topic named **Log Chain of Thoughts** and paste into the Code editor view:
+
+```yaml
+kind: AdaptiveDialog
+
+inputs:
+  - kind: AutomaticTaskInput
+    propertyName: CoT
+    description: High-level step summary for what you just did and why (no system prompts, secrets, PII, or raw chain-of-thought)
+    shouldPromptUser: false
+
+modelDescription: log chain of thoughts
+
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent: {}
+  actions:
+    - kind: SendActivity
+      id: sendActivity_9XILFq
+      activity: "_Thinking: {Topic.CoT}_"
+
+inputType:
+  properties:
+    CoT:
+      displayName: CoT
+      description: High-level step summary for what you just did and why (no system prompts, secrets, PII, or raw chain-of-thought)
+      type: String
+
+outputType: {}
+```
+
+## Agent Instruction to Add
+
+In the Copilot Studio instructions editor, reference the topic via the `/` dropdown so the exact topic name resolves correctly:
+
+```
+After every tool, topic, or step you take (except when you are already
+calling /Log Chain of Thoughts or other debug/logging topics), log your
+intermediate reasoning by calling /Log Chain of Thoughts.
+```
+
+The recursion guard is best-effort — it's natural language, not a hard stop. If you notice looping, tighten the wording or add a condition inside the topic.
+
+## Key Points
+
+| Element | Purpose |
+|---|---|
+| `AutomaticTaskInput.description` | Double-purpose — documentation + instruction telling the model what to put in the variable |
+| `shouldPromptUser: false` | Orchestrator fills the CoT value automatically instead of prompting the user |
+| `modelDescription` | Helps the orchestrator identify when to call this topic |
+| Italicized `SendActivity` (`_..._`) | Reads as a trace, not an "official" answer |
+| Input description excludes system prompts, secrets, PII, raw CoT | Security — orchestrator surfaces a high-level summary only |
+
+- **Extra credit cost** — each CoT log is an extra orchestrator call. Enable selectively (e.g., behind a debug flag or only on long-running agents)
+- **Multiple messages per response** — similar UX trade-off as the knowledge hold message; confirm with stakeholders before rollout
+- **Channel-agnostic** — `SendActivity` works on Teams, Copilot, web chat, and all other channels

--- a/skills/authoring-tips/conversation-history-variable.md
+++ b/skills/authoring-tips/conversation-history-variable.md
@@ -1,0 +1,87 @@
+# Conversation History as a Variable
+
+Capture the full conversation transcript at runtime by asking the orchestrator to dump it into a topic variable on demand. Enables summarization, live-agent handoff, ticket attachments, emailing a recap, or passing context to a downstream tool — all without rebuilding history turn-by-turn.
+
+> **Important:** This is a **best-effort transcript** reconstructed from the orchestrator's context window, not a verbatim record. Great for summarization, escalation, and contextual handoffs. For compliance-grade audit logs, use a dedicated logging solution.
+
+## When to Use This Pattern
+
+- The user needs to capture conversation context for escalation to a live agent
+- A downstream tool or connector requires conversation history as input
+- The user wants to log conversations to Dataverse, a ticketing system, or email
+- The agent needs to pass conversational context to another agent or flow
+
+## When NOT to Use
+
+- **Compliance-grade transcripts** — use a dedicated logging solution; this is not verbatim
+- **Very long conversations** — the transcript is bounded by the orchestrator's context window; capture incrementally or use a summary format
+
+## How It Works
+
+The orchestrator reads an input variable's `description` to decide what data to pass in — the same trick used in the [Chain of Thought Logging](chain-of-thought-logging.md) tip. The description tells the model "fill this with the full conversation in this format." The topic can either send the transcript as a message (useful for debugging or user-requested dumps) or store it as a variable to pass downstream.
+
+## YAML Example
+
+Create a topic named **Save Conversation History** and paste into the Code editor view. This version sends the history as a message:
+
+```yaml
+kind: AdaptiveDialog
+inputs:
+  - kind: AutomaticTaskInput
+    propertyName: ConversationHistory
+    description: "Entire conversation history in the format \"User: question <br /><br /> Agent : response <br /><br /> User: Question <br /><br /> Agent: response"
+    shouldPromptUser: false
+
+modelDescription: save the conversation history
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent: {}
+  actions:
+    - kind: SendActivity
+      id: sendActivity_gDSbH3
+      activity: "Here is your saved conversation history: {Topic.ConversationHistory}"
+
+inputType:
+  properties:
+    ConversationHistory:
+      displayName: ConversationHistory
+      description: "Entire conversation history in the format \"User: question <br /><br /> Agent : response <br /><br /> User: Question <br /><br /> Agent: response"
+      type: String
+
+outputType: {}
+```
+
+## Variations
+
+**Store as a variable instead of sending** — replace the `SendActivity` with a `SetVariable` that writes `Topic.ConversationHistory` to a global (or topic) variable. Pass that variable as input to a connector action, MCP server, or child agent.
+
+**Customize the format** — edit the `description` string. The orchestrator is flexible; ask for:
+- A summary instead of a full transcript
+- Specific speaker labels (or none)
+- Only the last N turns
+- A structured format for downstream processing (JSON-like, key/value, etc.)
+
+## Trigger Patterns
+
+- **Manual** — user types "save conversation history" or similar and the orchestrator routes via trigger phrases
+- **Automatic** — at end-of-conversation, escalation, or before ticket creation, call the topic with a **Recognize intent** node whose input text is `save conversation history`. The Recognize intent node programmatically invokes the orchestrator at any point in a flow
+
+## Key Points
+
+| Element | Purpose |
+|---|---|
+| `AutomaticTaskInput.description` | Instructs the orchestrator what to write into the variable (format + content) |
+| `shouldPromptUser: false` | Orchestrator fills the value automatically — no user prompt |
+| `modelDescription` | Helps the orchestrator identify when to call this topic |
+| `<br /><br />` in the format string | Produces line breaks between turns when rendered in chat (see [Line Breaks in Messages](line-breaks-in-messages.md)) |
+
+## Privacy and Security
+
+Transcripts can contain PII. When implementing:
+
+- Ensure you have proper user consent before capturing and storing transcripts
+- Send only what's needed — a summary is often sufficient and reduces PII exposure
+- Use secure storage with retention policies for anything persisted
+- Scope permissions so only authorized apps/people can access stored transcripts
+- When chaining to external tools (email, Dataverse, MCP), treat the full transcript as sensitive data

--- a/skills/authoring-tips/deterministic-mcp-calls.md
+++ b/skills/authoring-tips/deterministic-mcp-calls.md
@@ -1,0 +1,104 @@
+# Deterministic MCP Server Tool Calls
+
+Force an MCP server tool to fire reliably for a specific intent. MCP tools are generative actions — the orchestrator decides if and when to call them. Two platform limitations prevent true deterministic invocation today; this tip gives you the two available workarounds.
+
+## Current Platform Limitations
+
+- **No `/` syntax for MCP tools in instructions** — unlike topics and built-in actions, you cannot prefix an MCP tool name with `/` in agent instructions to force invocation
+- **No MCP tool nodes in topics** — topics can call connector actions and child agents, but MCP tools are only available to the orchestrator as generative actions
+
+Because of these, MCP tool calls are non-deterministic by default. Use Option 1 for a quick nudge, Option 2 for near-deterministic behavior.
+
+## When to Use This Pattern
+
+- A specific MCP tool must fire every time for a given user intent (compliance, data accuracy, business-critical workflows)
+- You've observed the orchestrator skipping the tool when you need it
+- You want to guarantee invocation rather than hoping the orchestrator picks the right tool
+
+## Option 1 — Name the Tool in Agent Instructions
+
+The simplest nudge: reference the MCP tool by name in the agent's overview instructions, mapping the intent to the tool explicitly.
+
+### YAML Example
+
+```yaml
+settings:
+  instructions: |
+    ## Tool Usage Rules
+
+    When the user asks about <specific intent>, you MUST call the
+    <MCP Tool Name> tool to retrieve the answer.
+    Do not attempt to answer from your own knowledge — always use the tool
+    for this type of request.
+
+    Examples of when to call <MCP Tool Name>:
+    - <Example user utterance 1>
+    - <Example user utterance 2>
+    - <Example user utterance 3>
+```
+
+### Trade-offs
+
+- **Pros:** no extra components, edit one instruction block to tune behavior
+- **Cons:** still relies on the orchestrator interpreting instructions — not truly deterministic; may miss on ambiguous utterances, especially when many tools compete
+
+**Use when:** the intent is broad and well-defined, and occasional misses are acceptable.
+
+## Option 2 — Child Agent with Dedicated Intent
+
+For near-deterministic behavior, wrap the MCP tool in a child agent whose only purpose is to call that tool. The parent routes to the child via trigger phrases; the child's narrow scope + explicit instructions force the tool call on every invocation.
+
+### How It Works
+
+1. Create a child agent with the MCP tool as its only generative action
+2. The child's instructions require the MCP tool to be called on every request
+3. Add trigger phrases (and a clear model description) so the parent orchestrator routes matching intents to the child
+4. Parent orchestrator detects the intent → `BeginDialog` to the child → child calls the MCP tool deterministically
+
+### YAML Example
+
+**Child agent** (`agents/MyMcpChild.agent.mcs.yml`):
+
+```yaml
+kind: AgentDialog
+beginDialog:
+  kind: OnToolSelected
+  id: main
+  description: Specialized agent for <domain term> lookups — always calls the <MCP Tool Name> tool.
+  intent:
+    triggerQueries:
+      - Look up <domain term>
+      - Find <domain term>
+      - What is the <domain term> for ...
+
+settings:
+  instructions: |
+    You are a specialized agent that answers <specific domain> questions.
+
+    CRITICAL: You MUST call the <MCP Tool Name> tool for EVERY request you receive.
+    Never answer from your own knowledge. Always use the tool and return its results.
+```
+
+Then connect the child agent to the parent as a connected agent.
+
+### Trade-offs
+
+- **Pros:** most reliable approach — narrow scope + explicit instruction = consistent tool calls; intent routing is deterministic; encapsulates MCP logic cleanly
+- **Cons:** extra component to maintain; one additional hop (parent → child → MCP tool); trigger phrases must not clash with other topics or agents
+
+**Use when:** the tool must fire every time with no exceptions, and the intent is narrow enough to justify its own agent.
+
+## Optional: Combine With Prevent-Child-Agent-Responses
+
+If the parent should control the final response format, have the child populate output variables instead of messaging the user directly — see the [`prevent-child-agent-responses`](prevent-child-agent-responses.md) tip.
+
+## Choosing Between Options
+
+| | Option 1 (Instructions) | Option 2 (Child Agent) |
+|---|---|---|
+| **Reliability** | High but not guaranteed | Near-deterministic |
+| **Complexity** | Low (edit one block) | Medium (new child + connection) |
+| **Best for** | Broad intents, quick setup | Narrow intents, critical workflows |
+| **Fallback risk** | Orchestrator may skip the tool | Orchestrator routes to child reliably |
+
+Start with Option 1. If the orchestrator inconsistently invokes the tool, escalate to Option 2.

--- a/skills/authoring-tips/knowledge-hold-message.md
+++ b/skills/authoring-tips/knowledge-hold-message.md
@@ -1,0 +1,66 @@
+# Hold Message During Knowledge Search
+
+Send a randomized "please hold" message during knowledge search so the user gets immediate feedback instead of staring at a silent screen while the orchestrator retrieves and summarizes results. Works on all channels (Teams, Copilot, web chat, custom) — the `OnKnowledgeRequested` trigger fires regardless of channel.
+
+## When to Use This Pattern
+
+- Your agent relies heavily on knowledge search and users experience noticeable wait times
+- You want a more conversational, human-like experience during knowledge retrieval
+- Users are abandoning conversations or resending questions during search delays
+- The model or channel doesn't support streaming — the user has no visual cue that work is happening
+
+## Trade-off: Two Messages per Response
+
+This pattern sends an **additional** message before the knowledge answer — users get two messages per question (hold + answer). Some organizations may dislike this chattiness. Confirm with stakeholders that the perceived-latency win is worth the extra message before rolling out.
+
+## How It Works
+
+1. A custom `OnKnowledgeRequested` topic fires automatically when the orchestrator decides to search knowledge
+2. A Power Fx `Table()` of ~40 hold messages is built inline (no external storage, no connector calls — runs in milliseconds)
+3. `Rand()` + `Index()` picks a random row
+4. `SendActivity` sends the chosen message
+5. The orchestrator then proceeds with its usual knowledge search and summarization
+
+## YAML Example
+
+Create a new topic and paste into the Code editor view:
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnKnowledgeRequested
+  id: main
+  actions:
+    - kind: SetVariable
+      id: setVariable_hM7xQ2
+      variable: init:Topic.HoldMessages
+      value: "=Table({Value: \"Let me dig into that for you...\"}, {Value: \"One moment while I look that up!\"}, {Value: \"Searching my knowledge base now...\"}, {Value: \"Give me just a sec to find that...\"}, {Value: \"On it! Let me check my sources...\"}, {Value: \"Hang tight, I'm pulling up the details...\"}, {Value: \"Great question! Let me research that...\"}, {Value: \"Looking into that right now...\"}, {Value: \"Let me find the best answer for you...\"}, {Value: \"Just a moment while I search for that information...\"}, {Value: \"I'm on the case! One moment please...\"}, {Value: \"Allow me to look that up for you...\"}, {Value: \"Checking my resources now...\"}, {Value: \"Let me see what I can find...\"}, {Value: \"Searching for the most relevant information...\"}, {Value: \"One sec while I hunt that down...\"}, {Value: \"Let me consult my knowledge sources...\"}, {Value: \"Working on finding that answer for you...\"}, {Value: \"Hold on while I track down those details...\"}, {Value: \"Researching that as we speak...\"}, {Value: \"Let me fetch that information for you...\"}, {Value: \"Give me a moment to pull that together...\"}, {Value: \"Scanning my knowledge base for you...\"}, {Value: \"I'll have that info in just a moment...\"}, {Value: \"Diving into the details now...\"}, {Value: \"Rummaging through my notes for you...\"}, {Value: \"Let me look into that for you right away...\"}, {Value: \"Checking on that now, one moment...\"}, {Value: \"Querying my sources for the best answer...\"}, {Value: \"Let me do a quick search on that...\"}, {Value: \"Pulling up the relevant info now...\"}, {Value: \"Bear with me while I find that...\"}, {Value: \"Sifting through the knowledge base...\"}, {Value: \"Let me round up the details for you...\"}, {Value: \"Looking that up right now, hang on...\"}, {Value: \"Just a sec, I want to give you a solid answer...\"}, {Value: \"Let me see what the docs say about that...\"}, {Value: \"Gathering the relevant information...\"}, {Value: \"Almost there, just searching for the best answer...\"}, {Value: \"On the hunt for that info now...\"})"
+
+    - kind: SetVariable
+      id: setVariable_rP4kN8
+      variable: init:Topic.SelectedMessage
+      value: =Index(Topic.HoldMessages, RoundDown(Rand() * CountRows(Topic.HoldMessages), 0) + 1).Value
+
+    - kind: SendActivity
+      id: sendActivity_wK9mT3
+      activity: "{Topic.SelectedMessage}"
+```
+
+> **Note:** `OnKnowledgeRequested` fires automatically when the orchestrator needs to search — no trigger phrases needed. You also do not add a search node; the orchestrator handles the search itself after this topic completes.
+
+## Alternative: Single Static Message
+
+If variety doesn't matter, strip the table and random-index logic and send one fixed string:
+
+```yaml
+- kind: SendActivity
+  id: sendActivity_wK9mT3
+  activity: "One moment while I search for that information..."
+```
+
+## Key Points
+
+- **Do not use an AI Builder prompt to generate messages** — the topic runs sequentially before the search, and an AI prompt adds ~4–6s of real latency on top of a ~7s search (nearly 80% slower). This defeats the purpose
+- **Customize the 40 messages** to match your brand tone — just edit the entries inside the `Table(...)` formula
+- **Channel-scoped hold message** — to show it only on specific channels (e.g., Teams), wrap the `SendActivity` in a `ConditionGroup` that checks `System.Activity.ChannelId`
+- **Optional delay** — to pause briefly before the hold message, build a tiny Agent Flow with a `Delay` action and call it between the random selection and the `SendActivity` node

--- a/skills/authoring-tips/line-breaks-in-messages.md
+++ b/skills/authoring-tips/line-breaks-in-messages.md
@@ -1,0 +1,81 @@
+# Line Breaks in Message and Question Nodes
+
+Insert `<br /><br />` inside `SendActivity` (message) and `Question` nodes to render paragraph breaks consistently across Teams, web chat, and other channels. Plain YAML newlines alone are rendered as spaces in most channels, so long messages turn into unreadable walls of text.
+
+## When to Use This Pattern
+
+- The agent sends longer messages that benefit from visual separation (welcome messages, instructions, summaries)
+- `Question` nodes include context or preamble before the actual question
+- Users report that bot messages feel like walls of text
+- You want consistent paragraph spacing across Teams, web chat, and other channels
+
+## How It Works
+
+- `<br />` — single line break
+- `<br /><br />` — double line break (paragraph spacing)
+- YAML `|-` block scalar preserves the literal newlines in the source file
+- Plain newlines (without `<br />`) are rendered as a single space in most channels
+
+## YAML Example
+
+**Message node:**
+
+```yaml
+- kind: SendActivity
+  id: sendActivity_QVhMj2
+  activity: |-
+    Hello! I'm a cool bot.
+    <br /><br />
+    I'm here to help you!
+```
+
+Renders as two visually separated paragraphs:
+
+> Hello! I'm a cool bot.
+>
+> I'm here to help you!
+
+**Question node with preamble:**
+
+```yaml
+- kind: Question
+  id: question_example
+  alwaysPrompt: true
+  variable: init:Topic.UserChoice
+  prompt: |-
+    I need a few details to get started.
+    <br /><br />
+    Please select one of the options below to continue.
+  entity:
+    kind: ClosedListEntityReference
+    entityId: yourAgentName.entity.YourEntity
+```
+
+**Multi-section message** — chain additional `<br /><br />` tags:
+
+```yaml
+- kind: SendActivity
+  id: sendActivity_multiSection
+  activity: |-
+    Welcome to the HR Support Bot!
+    <br /><br />
+    I can help you with:
+    - Leave requests
+    - Benefits enrollment
+    - Payroll questions
+    <br /><br />
+    Just type your question or select an option below to get started.
+```
+
+## Key Points
+
+| Syntax | Effect |
+|---|---|
+| `<br />` | Single line break |
+| `<br /><br />` | Paragraph spacing (double break) |
+| `|-` (YAML block scalar) | Preserves source newlines — required for multi-line `activity` / `prompt` |
+| Plain YAML newline (without `<br />`) | Rendered as a space in most channels |
+
+- **Always pair `<br /><br />` with `|-`** — the block scalar keeps the source readable; the `<br />` makes the rendered output consistent
+- **Use for both `SendActivity` and `Question`** — the same trick applies to the `activity` and `prompt` fields
+- **Works across channels** — Teams, Copilot web chat, and custom channels all render `<br />` reliably, whereas raw newlines are channel-dependent

--- a/skills/authoring-tips/prevent-child-agent-responses.md
+++ b/skills/authoring-tips/prevent-child-agent-responses.md
@@ -1,38 +1,71 @@
 # Prevent Child Agents from Responding Directly to Users
 
-When using child agents (connected agents), you may want the **parent agent** to control all communication with the user, while the child agent only returns data via output variables. This is a common requirement for orchestration patterns where the parent formats, filters, or enriches the child's output before presenting it.
-
-## Common Misconception: The Completion Setting
-
-The **completion setting** on a child agent is frequently misunderstood. It does **not** control whether the child agent sends messages to the user. It only determines what the **parent agent should do after the child agent finishes** (e.g., continue the conversation, end it, or return to the calling topic).
-
-Setting the completion behavior will not prevent the child agent from sending messages directly to the user during execution.
-
-## How to Prevent Direct Responses
-
-To stop a child agent from messaging the user, you must include explicit instructions in the **child agent's system instructions** that prohibit it from using the message tool. Add the following to the child agent's instructions:
-
-```
-CRITICAL - DO NOT MESSAGE USERS
-- DO NOT respond directly to the user
-- DO NOT call SendMessageTool or send any messages
-- ONLY populate the output variables with your response
-- Let the parent orchestrator deliver the response to the user
-```
-
-## Why This Works
-
-The child agent's orchestrator respects its system instructions. By explicitly forbidding `SendMessageTool` usage, the agent will place its response into the designated output variables instead of sending messages. The parent agent then reads those output variables and decides how to present the information to the user.
-
-## Implementation Steps
-
-1. **Define output variables on the child agent** — create the output variables (e.g., `AgentOutput`) that will carry the child's response back to the parent
-2. **Add the no-messaging instructions** — paste the instruction block above into the child agent's instructions field
-3. **Read output variables in the parent** — after the `BeginDialog` call to the child agent, use the returned output variables to craft the response in the parent agent's flow
+Force a child agent (connected agent) to return data only through **output variables** instead of messaging the user directly. This lets the parent agent control all user-facing communication — formatting, filtering, or enriching the child's output before presenting it.
 
 ## When to Use This Pattern
 
 - The parent agent needs to format or enrich the child's response before showing it to the user
 - Multiple child agents contribute partial answers that the parent combines
-- The parent agent applies business logic or filtering to the child's output
-- You want a consistent tone/format across all responses, regardless of which child agent produced the content
+- The parent applies business logic or filtering to the child's output
+- You want a consistent tone/format across all responses, regardless of which child produced the content
+
+## Common Misconception: The Completion Setting
+
+The **completion setting** on a child agent does **not** control whether it messages the user. It only determines what the **parent** does after the child finishes (continue, end, or return to the calling topic). Setting completion behavior will not silence the child during execution — explicit instructions are required.
+
+## How It Works
+
+1. Define `outputType` properties on the child agent to carry its response back to the parent
+2. Add an explicit "do not message" block to the child's `instructions` that forbids `SendMessageTool`
+3. In the parent, read the output variables after `BeginDialog` and craft the user-facing response yourself
+
+## YAML Example
+
+**Child agent** (`agents/MyChildAgent.agent.mcs.yml`):
+
+```yaml
+kind: AgentDialog
+beginDialog:
+  kind: OnToolSelected
+  id: main
+  description: Handles <specialization area> — returns structured data only.
+
+settings:
+  instructions: |
+    You are a specialist assistant that handles <specialization area>.
+
+    CRITICAL - DO NOT MESSAGE USERS
+    - DO NOT respond directly to the user
+    - DO NOT call SendMessageTool or send any messages
+    - ONLY populate the output variables with your response
+    - Let the parent orchestrator deliver the response to the user
+
+outputType:
+  properties:
+    AgentOutput:
+      displayName: Agent Output
+      description: Structured response for the parent to format and deliver.
+      type: String
+```
+
+**Parent topic** — read the output variable after calling the child:
+
+```yaml
+- kind: BeginDialog
+  id: callChild
+  dialog: cat_MyBot.agent.MyChildAgent
+  output:
+    binding:
+      AgentOutput: Topic.ChildResult
+
+- kind: SendActivity
+  id: formatAndSend
+  activity: "Here's what I found: {Topic.ChildResult}"
+```
+
+## Key Points
+
+- **Instructions, not settings, are what silence the child** — the orchestrator respects the child's system instructions and will choose output variables over `SendMessageTool` when explicitly forbidden
+- **Output variables are required** — without them the child has nowhere to put its response; define at least one `outputType` property
+- **Bind outputs in the parent's `BeginDialog`** — use the `output.binding` map to pull child output into a parent topic variable
+- **Parent owns the final message** — use `SendActivity` (or an Adaptive Card) in the parent to deliver the formatted response

--- a/skills/authoring-tips/rai-error-handling.md
+++ b/skills/authoring-tips/rai-error-handling.md
@@ -1,0 +1,153 @@
+# RAI Error Handling in OnError Topic
+
+Catch Azure OpenAI Responsible AI content-filter errors in the `OnError` topic, classify them by subcode, and deliver tailored, user-friendly messages instead of a generic error. Platform-level RAI filters are tuned for a general audience — this tip lets industry-specific agents (healthcare, education, government) provide empathetic, professional responses per filter category without weakening the filter itself.
+
+## When to Use This Pattern
+
+- Your agent handles sensitive topics where generic error messages are insufficient
+- You need category-specific responses (e.g., crisis resources for self-harm, security notifications for jailbreak attempts)
+- Administrators need visibility into which RAI categories trigger most often
+- Your industry requires tailored messaging for content-policy violations
+
+## Azure OpenAI RAI Subcodes
+
+All RAI errors arrive as `ContentFiltered`, but the subcode identifies the exact category:
+
+| Subcode | What It Catches |
+|---|---|
+| `OpenAIViolence` | Violent content, weapons, physical harm |
+| `OpenAIHate` | Hateful or discriminatory content |
+| `OpenAISexual` | Sexually explicit content |
+| `OpenAISelfHarm` | Self-injury or suicide content |
+| `OpenAIJailBreak` | **User** attempts to override system instructions / prompt injection |
+| `OpenAIndirectAttack` | Prompt attacks embedded in **external data** (documents, knowledge sources) |
+
+> **Note:** The subcode is `OpenAIndirectAttack` (not `OpenAIIndirectAttack`) — this matches the Azure OpenAI API spelling exactly. `OpenAIJailBreak` = the user attacks the model; `OpenAIndirectAttack` = a grounded document contains the attack.
+
+## How It Works
+
+1. `OnError` fires → capture a UTC timestamp for telemetry
+2. **AI Builder prompt** classifies the user's message into one of the subcodes (output → `Topic.ContentFilteringreason`)
+3. **Single `ConditionGroup`** evaluates the subcode switch-style and sends the matching response (fallback in `elseActions`)
+4. `LogCustomTelemetryEvent` records the incident, then `CancelAllDialogs` closes cleanly
+
+## Why a Single ConditionGroup (Switch-Style)
+
+Only one subcode matches per error. Putting each subcode in its own sequential `ConditionGroup` node evaluates them all independently, even after a match. A single `ConditionGroup` with all branches in `conditions` stops on first match, enables an `elseActions` fallback for future/unknown subcodes, and keeps all RAI handling in one node.
+
+## YAML Example
+
+Paste into the Code editor view of your **OnError** system topic:
+
+```yaml
+kind: AdaptiveDialog
+startBehavior: UseLatestPublishedContentAndCancelOtherTopics
+beginDialog:
+  kind: OnError
+  id: main
+  actions:
+    - kind: SetVariable
+      id: setVariable_timestamp
+      variable: init:Topic.CurrentTime
+      value: =Text(Now(), DateTimeFormat.UTC)
+
+    - kind: InvokeAIBuilderModelAction
+      id: invokeAIBuilderModelAction_xxoZmJ
+      input:
+        binding:
+          User_20Message: =System.Activity.Text
+      output:
+        binding:
+          predictionOutput: Topic.ContentFilteringreason
+      aIModelId: <YOUR_AI_BUILDER_MODEL_ID>
+
+    - kind: ConditionGroup
+      id: conditionGroup_raiSwitch
+      conditions:
+        - id: cond_Vl8mRk
+          condition: =Topic.ContentFilteringreason.text = "OpenAIViolence"
+          actions:
+            - kind: SendActivity
+              id: sendMessage_Vl8mRk
+              activity: "[PLACEHOLDER] Your message was flagged for violent content. Please rephrase your request."
+
+        - id: cond_Ht4nQw
+          condition: =Topic.ContentFilteringreason.text = "OpenAIHate"
+          actions:
+            - kind: SendActivity
+              id: sendMessage_Ht4nQw
+              activity: "[PLACEHOLDER] Your message was flagged for hateful or discriminatory content."
+
+        - id: cond_Sx7pLe
+          condition: =Topic.ContentFilteringreason.text = "OpenAISexual"
+          actions:
+            - kind: SendActivity
+              id: sendMessage_Sx7pLe
+              activity: "[PLACEHOLDER] Your message was flagged for sexually explicit content."
+
+        - id: cond_Sh9tWz
+          condition: =Topic.ContentFilteringreason.text = "OpenAISelfHarm"
+          actions:
+            - kind: SendActivity
+              id: sendMessage_Sh9tWz
+              activity: "[PLACEHOLDER] If you or someone you know is in crisis, please contact emergency services or a crisis helpline."
+
+        - id: cond_Jb2kAx
+          condition: =Topic.ContentFilteringreason.text = "OpenAIJailBreak"
+          actions:
+            - kind: SendActivity
+              id: sendMessage_Jb2kAx
+              activity: "[PLACEHOLDER] Your message was flagged as an attempt to override system instructions."
+
+        - id: cond_Ia5rNv
+          condition: =Topic.ContentFilteringreason.text = "OpenAIndirectAttack"
+          actions:
+            - kind: SendActivity
+              id: sendMessage_Ia5rNv
+              activity: "[PLACEHOLDER] A prompt injection attack was detected in external data. The request has been blocked."
+
+      elseActions:
+        - kind: SendActivity
+          id: sendMessage_dZ0gaF
+          activity:
+            text:
+              - |-
+                An error has occurred.
+                Error code: {System.Error.Code}
+                Conversation Id: {System.Conversation.Id}
+                Time (UTC): {Topic.CurrentTime}.
+            speak:
+              - An error has occurred, please try again.
+
+    - kind: LogCustomTelemetryEvent
+      id: 9KwEAn
+      eventName: OnErrorLog
+      properties: "={ErrorMessage: System.Error.Message, ErrorCode: System.Error.Code, TimeUTC: Topic.CurrentTime, ConversationId: System.Conversation.Id}"
+
+    - kind: CancelAllDialogs
+      id: NW7NyY
+```
+
+## AI Builder Classifier Prompt
+
+The plugin cannot create AI Builder models — add the prompt node manually in the Copilot Studio UI with input `System.Activity.Text` and output `Topic.ContentFilteringreason`. Use this prompt body:
+
+```
+Analyze the following user message and identify which Azure OpenAI Content Filter subcode
+would be triggered. Output **only** the exact subcode — nothing else.
+
+Subcodes: OpenAIViolence, OpenAIHate, OpenAISexual, OpenAISelfHarm,
+          OpenAIJailBreak, OpenAIndirectAttack
+
+OpenAIJailBreak = user tries to manipulate the model.
+OpenAIndirectAttack = external/grounded data contains the attack.
+
+Output only the exact matching subcode. Example: OpenAIViolence
+```
+
+## Key Points
+
+- **Platform RAI filtering is untouched** — this pattern only changes the *message delivered to the user* after the platform filters fire
+- **Variable name must match exactly** — `Topic.ContentFilteringreason` (lowercase "r") in both the AI Builder output binding and ConditionGroup conditions
+- **Replace every `[PLACEHOLDER]`** with your organization's approved response text, and replace `aIModelId` with your own AI Builder model ID
+- **`elseActions` catches new subcodes** — Azure OpenAI may add categories; the fallback ensures graceful handling until you add a branch

--- a/skills/patterns/SKILL.md
+++ b/skills/patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 user-invocable: false
 name: patterns
-description: "Index of repeatable implementation patterns for Copilot Studio agents. When a request may need a best-practice architecture or reusable pattern for building an agent capability, retrieve this index before deciding what detailed guidance is relevant. Do not decide from this frontmatter alone; use the index summaries, then open only the specific pattern file if needed. Do not use for general knowledge sources or topic creation."
+description: "Index of repeatable implementation patterns for Copilot Studio agents. When a request may need a best-practice architecture or reusable pattern for building an agent capability, retrieve this index before deciding what detailed guidance is relevant. Do not decide from this frontmatter alone; use the index summaries, then open only the specific pattern file if needed. Do not use for general knowledge sources or topic creation. USE FOR: glossary, acronyms, terminology, CSV, SharePoint, JIT, user context, country, department, M365 profile, GetMyProfile, AutomaticTaskInput, shouldPromptUser, orchestrator-generated inputs, conversation-init, Teams deployment, Microsoft Teams, Teams agent, production hardening, OnInstallationUpdate, app reinstall, OnInactivity, stale context, clear ConversationHistory, Global.InactiveConversation, cross-channel context, Microsoft 365 Copilot, M365 Copilot, Global.UserContext, IsBlank context, Reset Conversation, OnSystemRedirect, Start Over, YesNo entity, Adaptive Card confirmation, OnError card, self-serve troubleshooting, diagnostics panel, System.Bot.Id, System.Conversation.Id, LogCustomTelemetryEvent, OnErrorLog, suggested prompts, conversationStarters."
 context: fork
 agent: copilot-studio-author
 ---
@@ -42,3 +42,15 @@ Uses `AutomaticTaskInput` to let the orchestrator's LLM classify or extract stru
 ## Combining Patterns
 
 You can combine more than one pattern. For example, when using both glossary and user context, merge them into a **single** `conversation-init` topic rather than creating separate OnActivity topics. Use the template at `${CLAUDE_SKILL_DIR}/../../templates/topics/conversation-init.topic.mcs.yml`. The individual files explain the details.
+
+## Teams Production Hardening → [teams-production-hardening.md](teams-production-hardening.md)
+
+Coordinated framework of eight production patterns for Copilot Studio agents deployed to Microsoft Teams and Microsoft 365 Copilot. Covers app reinstalls (`OnActivity InstallationUpdate`), stale-context handling (`OnInactivity` + follow-up notification), cross-channel context initialization (`Global.UserContext` via priority-based `OnActivity` guarded by `IsBlank`), rebuilt Reset Conversation and Start Over system topics with Adaptive Card confirmation and diagnostics panel, rich `OnError` card with self-serve troubleshooting and telemetry, and agent-level suggested prompts.
+
+**Read this pattern when:**
+- The user is deploying (or hardening) a Copilot Studio agent on Microsoft Teams
+- Users report stale context after returning to a long-running Teams conversation
+- Context variables (country, language, department) work on web chat but not in Microsoft 365 Copilot
+- The user wants richer `OnError` or Start Over experiences with diagnostic info for help-desk escalation
+- The user asks about `OnInstallationUpdate`, `OnInactivity`, `OnSystemRedirect`, suggested prompts, or Teams-specific agent behavior
+- The user wants to reduce token usage by clearing idle conversation history

--- a/skills/patterns/teams-production-hardening.md
+++ b/skills/patterns/teams-production-hardening.md
@@ -1,0 +1,328 @@
+# Teams Production Hardening for Copilot Studio Agents
+
+A coordinated set of eight production patterns for Copilot Studio agents deployed to Microsoft Teams (and, where applicable, Microsoft 365 Copilot). Addresses app reinstalls, stale conversation context, cross-channel variable initialization, user-friendly reset/troubleshooting flows, and self-serve error diagnostics. The patterns are designed to work together — variables set by one pattern are read by others — so treat this as a framework to adopt end-to-end, not a pick-and-mix list.
+
+**Source:** <https://microsoft.github.io/mcscatblog/posts/copilot-studio-teams-agent-patterns/>
+
+## Framework Overview
+
+```
+                  ┌──────────────────────────────────────────┐
+                  │  User opens agent in Teams / M365 Copilot │
+                  └──────────────────┬───────────────────────┘
+                                     │
+          ┌──────────────────────────┼──────────────────────────┐
+          │                          │                          │
+┌─────────▼─────────┐    ┌───────────▼────────────┐   ┌─────────▼──────────┐
+│ 1. OnInstallation │    │ 4. SetContextVariables │   │ 8. Suggested       │
+│    Update         │    │    (fires if blank)    │   │    prompts (config)│
+│    → ConvStart    │    │    → Global.UserContext│   └────────────────────┘
+└─────────┬─────────┘    └────────────────────────┘
+          │                          ▲
+          ▼                          │
+   ConversationStart ─────────────> reads Global.UserContext
+
+   ┌───────────────────────────────────────────────┐
+   │ 2. OnInactivity (12h) ──► clear vars          │
+   │                           set Global.Inactive │
+   │                                               │
+   │ 3. OnActivity (Inactive=true) ──► notify +    │
+   │                                    "Start over"│
+   └─────────────────────┬─────────────────────────┘
+                         │
+                         ▼
+         ┌───────────────────────────────────┐
+         │ 6. Start Over (Adaptive Card)     │
+         │    Yes  ──► 5. Reset Conversation │
+         │    No   ──► continue              │
+         │    Diagnostics panel inline       │
+         └───────────────┬───────────────────┘
+                         ▼
+         ┌───────────────────────────────────┐
+         │ 5. Reset Conversation             │
+         │    Clear scoped vars + history    │
+         │    Redirect to ConversationStart  │
+         └───────────────────────────────────┘
+
+   ┌───────────────────────────────────────────────┐
+   │ 7. OnError (Adaptive Card)                    │
+   │    Error details + diagnostics + "Start over" │
+   │    LogCustomTelemetryEvent                    │
+   └───────────────────────────────────────────────┘
+```
+
+## Shared Variables
+
+| Variable | Set by | Read by | Purpose |
+|---|---|---|---|
+| `Global.InactiveConversation` | Pattern 2 (set true), Pattern 3 (reset false) | Pattern 3 | Flag that signals the next user message should render the "session expired" card |
+| `Global.UserContext` | Pattern 4 | Agent instructions, all topics | Structured user context (Country, Language, …) surviving resets and M365 Copilot channel |
+| `Topic.Confirm` | Pattern 6 | Pattern 6 branches | Yes/No answer to the restart confirmation |
+
+## When to Use This Framework
+
+- Your agent is deployed (or will be) to Microsoft Teams — especially with long-running persistent conversations
+- You want consistent behavior across Teams and Microsoft 365 Copilot (M365 Copilot does not fire `OnConversationStart`)
+- Users report stale context, confusing resets, or generic error messages with no path to action
+- You need self-serve diagnostics for help-desk escalations (agent ID, conversation ID, environment ID, etc.)
+
+## Implementation
+
+Apply in the order listed. Earlier patterns set variables that later ones depend on.
+
+### Pattern 1 — Handle App Reinstalls
+
+**Problem:** When a user uninstalls and reinstalls the Teams app, the Conversation Start system topic does **not** fire. The user lands on an empty chat with no greeting or onboarding guidance.
+
+**Solution:** New topic with an `OnActivity` trigger of type `InstallationUpdate` that redirects to the Conversation Start topic. `startBehavior: UseLatestPublishedContentAndCancelOtherTopics` ensures the topic runs the latest published version and supersedes stale in-flight dialogs.
+
+```yaml
+kind: AdaptiveDialog
+startBehavior: UseLatestPublishedContentAndCancelOtherTopics
+beginDialog:
+  kind: OnActivity
+  id: main
+  type: InstallationUpdate
+  actions:
+    - kind: BeginDialog
+      id: Bqmh4L
+      dialog: cat_B2EAgent.topic.ConversationStart
+```
+
+**Replace** `cat_B2EAgent.topic.ConversationStart` with your agent's fully-qualified Conversation Start topic name (see `settings.mcs.yml` for the `cat_*` prefix).
+
+---
+
+### Pattern 2 — Clear Stale Context After Inactivity
+
+**Problem:** Teams persists conversations indefinitely. A user returning after days to continue an unrelated task sees the agent operate with stale `ConversationHistory`, producing confused answers.
+
+**Solution:** `OnInactivity` trigger (12h example — tune `durationInSeconds` to your scenario). Clears `ConversationHistory`, clears session variables, sets `Global.InactiveConversation = true` so Pattern 3 can notify the user on their next message, and cancels all dialogs.
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnInactivity
+  id: main
+  condition: =System.Activity.ChannelId = "msteams"
+  durationInSeconds: 43200
+  actions:
+    - kind: ClearAllVariables
+      id: mXHosp
+      variables: ConversationHistory
+    - kind: ClearAllVariables
+      id: Vsemgr
+    - kind: SetVariable
+      id: setVariable_6CUITr
+      variable: Global.InactiveConversation
+      value: true
+    - kind: CancelAllDialogs
+      id: webE3j
+inputType: {}
+outputType: {}
+```
+
+**Secondary benefit:** clearing `ConversationHistory` on long-idle sessions also reduces token usage on the next turn.
+
+---
+
+### Pattern 3 — Notify User After Inactivity-Triggered Reset
+
+**Problem:** After Pattern 2 clears context, the user doesn't know why the agent "forgot" them. Without a message they send a follow-up expecting continuity and get inconsistent behavior.
+
+**Solution:** `OnActivity` (type: Message) guarded by the `Global.InactiveConversation` flag. Immediately resets the flag, then renders a Hero Card explaining the session expired with a persistent **Start over** button.
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnActivity
+  id: main
+  condition: =Global.InactiveConversation = true
+  type: Message
+  actions:
+    - kind: SetVariable
+      id: setVariable_G6aAbW
+      variable: Global.InactiveConversation
+      value: false
+    - kind: SendActivity
+      id: sendActivity_pgGjvA
+      activity:
+        attachments:
+          - kind: HeroCardTemplate
+            title: Session expired
+            subtitle: New conversation started
+            text: ℹ️ Your previous session ended due to inactivity. Your query is now treated as new. Restart anytime.
+            buttons:
+              - kind: MessageBack
+                title: Start over
+                text: Start over
+inputType: {}
+outputType: {}
+```
+
+The **Start over** button posts the literal text `Start over`, which your agent should recognize and route to the Start Over system topic (Pattern 6).
+
+---
+
+### Pattern 4 — Set Global Context Variables Cross-Channel
+
+**Problem:** Context variables (language, country, department, etc.) are typically populated in `OnConversationStart`. But `OnConversationStart` **does not fire in Microsoft 365 Copilot** and is lost after resets (Patterns 2 and 5 both clear variables). The result: same agent, different behavior across channels.
+
+**Solution:** Dedicated `SetContextVariables` topic with `OnActivity (type: Message)` + `priority: -2` + `condition: =IsBlank(Global.UserContext)`. Fires exactly once on the first user message when context isn't set yet, regardless of channel or reset history.
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnActivity
+  id: main
+  priority: -2
+  condition: =IsBlank(Global.UserContext)
+  type: Message
+  actions:
+    - kind: SetVariable
+      id: setVariable_kRbCMi
+      variable: Global.UserContext
+      value: |-
+        ={
+            Country: "USA",
+            Language: "English"
+        }
+inputType: {}
+outputType: {}
+```
+
+- **Structured object** — use a record literal (`={...}`) so instructions can reference `{Global.UserContext.Country}`, `{Global.UserContext.Language}`, etc.
+- **Replace hard-coded values** with calls to the M365 Users connector for real user profile data (see the JIT User Context pattern in this plugin)
+- **Reference in instructions** — add a directive to your agent instructions like "Use `{Global.UserContext.Country}` when tailoring answers" and "If `Global.UserContext` is blank, trigger `/Set Context Variables` before answering"
+
+**Why `priority: -2`** — negative priorities run before standard triggers, ensuring context is populated before any knowledge search or topic routing evaluates the first message.
+
+---
+
+### Pattern 5 — Rebuild the Reset Conversation System Topic
+
+**Problem:** The default Reset Conversation topic clears some state but does not clear `ConversationHistory` and does not redirect users back to the onboarding/greeting flow — leaving them in a half-reset state.
+
+**Solution:** Override the `OnSystemRedirect` Reset Conversation topic to clear `ConversationScopedVariables` and `ConversationHistory`, redirect to Conversation Start (which re-triggers Pattern 4 to repopulate context), then cancel all dialogs. `startBehavior: UseLatestPublishedContentAndCancelOtherTopics` forces the published version.
+
+```yaml
+kind: AdaptiveDialog
+startBehavior: UseLatestPublishedContentAndCancelOtherTopics
+beginDialog:
+  kind: OnSystemRedirect
+  id: main
+  actions:
+    - kind: ClearAllVariables
+      id: clearAllVariables_73bTFR
+      variables: ConversationScopedVariables
+    - kind: ClearAllVariables
+      id: SLgE7u
+      variables: ConversationHistory
+    - kind: BeginDialog
+      id: U14iCH
+      dialog: cat_B2EAgent.topic.ConversationStart
+    - kind: CancelAllDialogs
+      id: cancelAllDialogs_12Gt21
+```
+
+**Replace** `cat_B2EAgent.topic.ConversationStart` with your agent's fully-qualified topic schema name.
+
+---
+
+### Pattern 6 — Rebuild Start Over with Adaptive Card + Diagnostics
+
+**Problem:** The default Start Over dialog is a bare yes/no prompt. Users want confirmation language, and when things go wrong, help-desk engineers need diagnostic IDs (environment, tenant, agent, conversation) that users can copy-paste.
+
+**Solution:** Replace the default Boolean question with an Adaptive Card question using a closed-list `YesNo` entity. The card shows:
+
+- Confirmation header + explanation
+- Yes / No action buttons
+- Collapsed **Advanced options** panel with:
+  - Troubleshooting actions: `Clear state` (`/debug clearstate`), `Clear history` (`/debug clearhistory`), `Conversation ID` (`/debug conversationid`)
+  - Environment details: `System.Bot.EnvironmentId`, `System.Bot.TenantId`
+  - Agent details: `System.Bot.Name`, `System.Bot.Id`, `System.Bot.SchemaName`
+  - User details: `System.User.Language`, `System.User.Id`
+  - Conversation details: `System.Activity.ChannelId`, `System.Conversation.Id`, `Text(Now(), DateTimeFormat.UTC)`
+
+**Branches** (Power Fx on `Topic.Confirm`):
+- `Yes` → `BeginDialog` to the Reset Conversation topic (Pattern 5)
+- `No` → `SendActivity: "Ok. Let's carry on."` + `RecognizeIntent` on user input to get back to the normal flow
+
+**Setup steps:**
+
+1. Create a closed-list entity `YesNo` with items `Yes` and `No` (plus synonyms if needed)
+2. Open the system **Start Over** topic
+3. Replace the Boolean question node with a `Question` node using `ClosedListEntityReference` → `<agent>.entity.YesNo`, capturing into `Topic.Confirm`
+4. Put the Adaptive Card structure described above as the `prompt` of that Question node
+5. Add two `ConditionGroup` branches on `Topic.Confirm` — one for Yes (BeginDialog → Reset Conversation), one for No (SendActivity + RecognizeIntent)
+
+See the blog post for the full Adaptive Card JSON; reproduce the structure as-is and swap text/branding to match your agent.
+
+---
+
+### Pattern 7 — Self-Serve OnError Topic with Adaptive Card + Telemetry
+
+**Problem:** Generic "Something went wrong" messages leave users stuck and give engineers nothing actionable when they escalate.
+
+**Solution:** Override the `OnError` system topic with a rich Adaptive Card that shows the error details, exposes the same diagnostic panel as Pattern 6, and logs telemetry. `startBehavior: UseLatestPublishedContentAndCancelOtherTopics` forces the published version.
+
+**Adaptive Card structure** (inside the `SendActivity`):
+
+- Header: `⚠️ Something went wrong` + short apology text
+- Error details (attention-styled container, ColumnSets):
+  - `System.Error.Message`
+  - `System.Error.Code`
+  - `System.Conversation.Id`
+  - `Text(Now(), DateTimeFormat.UTC)`
+- Collapsed **Advanced options** panel, identical to Pattern 6's:
+  - Troubleshooting buttons: Start over, Clear state, Clear history, Conversation ID
+  - Environment / Agent / User / Conversation diagnostic ColumnSets
+
+**Telemetry logging node:**
+
+```yaml
+- kind: LogCustomTelemetryEvent
+  id: 9KwEAn
+  eventName: OnErrorLog
+  properties: "={ErrorMessage: System.Error.Message, ErrorCode: System.Error.Code, TimeUTC: Text(Now(), DateTimeFormat.UTC), ConversationId: System.Conversation.Id}"
+```
+
+**End the topic with `CancelAllDialogs`** so the user returns to a clean state.
+
+> Combines naturally with the `rai-error-handling` authoring tip — use that tip's AI Builder classifier + subcode ConditionGroup inside this same OnError topic before the error card, so content-filter errors get category-specific messages while all other errors fall through to the generic diagnostic card.
+
+---
+
+### Pattern 8 — Configure Suggested Prompts at Agent Level
+
+**Problem:** Users don't know what the agent can do. Discovery is inconsistent across Teams and M365 Copilot.
+
+**Solution:** Define 3–4 suggested prompts at the **agent** level (not topic level). They surface on initial conversation start in both Teams and Microsoft 365 Copilot, guiding users toward effective queries without blocking free-form input.
+
+**Setup steps:**
+
+1. Open agent **Settings**
+2. Navigate to **Generative AI → Suggested prompts**
+3. Add 3–4 prompts aligned to your agent's core capabilities
+4. Save at agent level
+
+This is configuration-only — no topic YAML. In the YAML files it surfaces as the `conversationStarters` block in `agent.mcs.yml` / `settings.mcs.yml`.
+
+## Validation Checklist
+
+Test in this order — later tests depend on earlier patterns being in place:
+
+- [ ] **Pattern 1** — Uninstall + reinstall the Teams app → Conversation Start greeting appears
+- [ ] **Pattern 4** — Open the agent in Microsoft 365 Copilot (where `OnConversationStart` doesn't fire) → verify `Global.UserContext` populates before the first answer
+- [ ] **Pattern 2 + 3** — Idle for longer than `durationInSeconds` (drop the value temporarily for testing) → send a message → "Session expired" Hero Card appears with **Start over** button
+- [ ] **Pattern 6** — Trigger Start Over → Adaptive Card renders with confirmation + Advanced options containing correct IDs from `System.Bot.*` / `System.Conversation.Id`
+- [ ] **Pattern 5** — Confirm Yes in Pattern 6's card → history clears, Conversation Start re-runs, `Global.UserContext` is repopulated by Pattern 4
+- [ ] **Pattern 7** — Force a runtime error (e.g., hit a broken connector action) → error Adaptive Card renders with `System.Error.Message`, `System.Error.Code`, conversation ID, UTC timestamp; telemetry event `OnErrorLog` appears in Application Insights
+- [ ] **Pattern 8** — New conversation → 3–4 suggested prompts appear below the chat input in both Teams and M365 Copilot
+
+## Notes
+
+- **Schema-name prefix** — every `BeginDialog` dialog reference (`cat_B2EAgent.topic.*`) uses your agent's schema name prefix. Read `settings.mcs.yml` to find yours before pasting.
+- **`startBehavior: UseLatestPublishedContentAndCancelOtherTopics`** — applied on Patterns 1, 5, and 7 to force the latest published version and supersede any in-flight version of the same dialog.
+- **Channel scoping** — Pattern 2's `condition: =System.Activity.ChannelId = "msteams"` limits inactivity handling to Teams. Remove the condition to apply to all channels, or adapt per target channel.
+- **Diagnostics duplication** — Patterns 6 and 7 deliberately use the *same* Advanced options panel so users see a consistent diagnostic experience regardless of whether they hit Start Over or an error.


### PR DESCRIPTION


Authoring Tips (new):
- rai-error-handling: RAI content-filter error classification in OnError
- line-breaks-in-messages: <br /> for paragraph spacing in SendActivity/Question
- knowledge-hold-message: Random hold messages during knowledge search
- deterministic-mcp-calls: Force MCP tool invocation via instructions or child agent
- chain-of-thought-logging: Surface orchestrator reasoning as Thinking messages
- conversation-history-variable: Capture transcript via AutomaticTaskInput

Authoring Tips (updated):
- prevent-child-agent-responses: Added YAML examples for child and parent agents

Patterns (new):
- teams-production-hardening: 8-pattern framework for Teams deployment

SKILL.md updates:
- Added routing entries and USE FOR keywords for all new content