### PR TITLE
Add 7 new patterns to be used by the Advisor agent

### DIFF
--- a/patterns/chain-of-thought-logging.md
+++ b/patterns/chain-of-thought-logging.md
@@ -1,0 +1,90 @@
+---
+name: Chain of Thought Logging
+description: Send high-level "Thinking" messages during multi-step orchestration to improve observability and perceived responsiveness.
+challenge: Multi-tool or multi-agent flows can leave users waiting in silence with no visibility into what the agent is doing.
+status: recommended
+tags: [chain-of-thought, CoT, AutomaticTaskInput, reasoning-trace, observability, thinking-messages]
+---
+
+## Pattern
+
+This pattern creates a lightweight logging topic that turns orchestration progress into italicized `_Thinking: ..._` chat messages. It is useful for multi-step tool chains, MCP calls, child-agent orchestration, and reasoning-heavy models where users would otherwise experience 10 to 30 seconds of silence.
+
+### How it works
+
+The orchestrator reads an input variable's `description` to decide what data to supply, so the description doubles as an instruction. The logger topic accepts a CoT summary through `AutomaticTaskInput`, then immediately sends it as a user-visible trace message.
+
+For non-reasoning models such as GPT-4.1 and GPT-5 Chat, this technique surfaces reasoning that would otherwise stay hidden. For reasoning models, the orchestrator narrates a safe high-level summary rather than exposing raw internal chain-of-thought.
+
+> **Tested with:** GPT-4.1, GPT-5 Chat, GPT-5 Auto, GPT-5 Reasoning, Claude Sonnet, Claude Opus.
+
+### Example user experience
+
+```
+User: "What's the latest status on Project Alpha?"
+Agent: _Thinking: Looking up Project Alpha in the project tracker..._
+Agent: _Thinking: Found 3 recent updates. Checking team assignments..._
+Agent: _Thinking: Cross-referencing with the deadline calendar..._
+Agent: Here's the latest on Project Alpha: <final answer>
+```
+
+### Instruction to add
+
+In the Copilot Studio instructions editor, reference the topic via the `/` dropdown so the topic name resolves correctly:
+
+```
+After every tool, topic, or step you take (except when you are already
+calling /Log Chain of Thoughts or other debug/logging topics), log your
+intermediate reasoning by calling /Log Chain of Thoughts.
+```
+
+The recursion guard is best-effort because it relies on natural-language instructions, not a hard platform stop.
+
+## When to Use
+
+- Your agent uses multiple tools, MCP servers, or child agents that chain together.
+- Users experience long waits during multi-step reasoning with no feedback.
+- You need a debug or observability aid to see what the orchestrator is doing step by step.
+- The agent uses reasoning models where extended thinking creates long silent pauses.
+
+## YAML Example
+
+**Log Chain of Thoughts topic** (create a topic named `Log Chain of Thoughts` and paste into the Code editor view):
+
+```yaml
+kind: AdaptiveDialog
+
+inputs:
+  - kind: AutomaticTaskInput
+    propertyName: CoT
+    description: High-level step summary for what you just did and why (no system prompts, secrets, PII, or raw chain-of-thought)
+    shouldPromptUser: false
+
+modelDescription: log chain of thoughts
+
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent: {}
+  actions:
+    - kind: SendActivity
+      id: sendActivity_9XILFq
+      activity: "_Thinking: {Topic.CoT}_"
+
+inputType:
+  properties:
+    CoT:
+      displayName: CoT
+      description: High-level step summary for what you just did and why (no system prompts, secrets, PII, or raw chain-of-thought)
+      type: String
+
+outputType: {}
+```
+
+## Pitfalls
+
+- Do not use this for pure knowledge-search agents; a simple knowledge hold message is usually a better fit.
+- Each log is an extra orchestrator call, so this increases Copilot credit consumption.
+- Multiple `_Thinking: ..._` messages can make the conversation busier; validate the UX with stakeholders.
+- Keep the `AutomaticTaskInput.description` strict so the orchestrator does not leak secrets, PII, system prompts, or raw chain-of-thought.
+- If you notice loops, tighten the recursion guard wording or add additional defensive conditions around when the topic is called.

--- a/patterns/chain-of-thought-logging.md
+++ b/patterns/chain-of-thought-logging.md
@@ -12,9 +12,9 @@ This pattern creates a lightweight logging topic that turns orchestration progre
 
 ### How it works
 
-The orchestrator reads an input variable's `description` to decide what data to supply, so the description doubles as an instruction. The logger topic accepts a CoT summary through `AutomaticTaskInput`, then immediately sends it as a user-visible trace message.
+The topic declares an `AutomaticTaskInput` variable with `shouldPromptUser: false`. The orchestrator reads the variable's `description` field to understand what data to fill in — for example, a high-level summary of the step it just completed — and populates the variable automatically. The topic then sends that value as an italicized `_Thinking: ..._` chat message.
 
-For non-reasoning models such as GPT-4.1 and GPT-5 Chat, this technique surfaces reasoning that would otherwise stay hidden. For reasoning models, the orchestrator narrates a safe high-level summary rather than exposing raw internal chain-of-thought.
+This works across both reasoning and non-reasoning models. The orchestrator narrates its own actions (which tool it called, which agent it routed to, what it found) regardless of the underlying model's architecture. For reasoning models, the orchestrator provides a safe high-level summary rather than exposing raw internal chain-of-thought.
 
 > **Tested with:** GPT-4.1, GPT-5 Chat, GPT-5 Auto, GPT-5 Reasoning, Claude Sonnet, Claude Opus.
 
@@ -30,7 +30,7 @@ Agent: Here's the latest on Project Alpha: <final answer>
 
 ### Instruction to add
 
-In the Copilot Studio instructions editor, reference the topic via the `/` dropdown so the topic name resolves correctly:
+Add the following to the agent instructions. In the Copilot Studio UI editor, type `/` to auto-complete the topic name. If editing YAML directly, use the exact topic name as written:
 
 ```
 After every tool, topic, or step you take (except when you are already

--- a/patterns/conversation-history-variable.md
+++ b/patterns/conversation-history-variable.md
@@ -1,0 +1,79 @@
+---
+name: Conversation History Variable
+description: Capture a best-effort conversation transcript into a variable for escalation, logging, and downstream automation.
+challenge: Agents often need the current conversation context for handoff or logging, but rebuilding the transcript turn by turn is cumbersome and fragile.
+status: proven
+tags: [conversation-history, transcript, AutomaticTaskInput, escalation, handoff, logging]
+---
+
+## Pattern
+
+This pattern asks the orchestrator to reconstruct the current conversation and place it into a topic variable on demand. The result can be shown to the user, stored, summarized, attached to a ticket, emailed, or passed to a downstream connector, MCP tool, or child agent.
+
+> **Important:** This is a **best-effort transcript** reconstructed from the orchestrator's context window, not a verbatim record. It is useful for summarization, escalation, and contextual handoffs, but not for compliance-grade audit logging.
+
+### How it works
+
+The orchestrator reads an input variable's `description` to decide what to populate, so the description doubles as an instruction. In this pattern, the description tells the model to fill `ConversationHistory` with the full conversation in a specific format.
+
+### Variations
+
+- **Store instead of send** — replace the `SendActivity` with a `SetVariable` that copies `Topic.ConversationHistory` into a topic or global variable for downstream use.
+- **Customize the format** — edit the `description` string if you want a summary, only the last N turns, different speaker labels, or a more structured format.
+- **Trigger automatically** — call the topic from a `RecognizeIntent` node with input text like `save conversation history` at escalation time, end-of-conversation, or before creating a ticket.
+
+### Key implementation details
+
+| Element | Purpose |
+|---|---|
+| `AutomaticTaskInput.description` | Instructs the orchestrator what content and format to place in the variable |
+| `shouldPromptUser: false` | The orchestrator fills the value automatically instead of prompting the user |
+| `modelDescription` | Helps the orchestrator identify when to call the topic |
+| `<br /><br />` in the requested format | Produces readable line breaks between turns when rendered in chat |
+
+## When to Use
+
+- The user needs conversation context captured for escalation to a live agent.
+- A downstream tool or connector requires conversation history as input.
+- You want to log conversations to Dataverse, a ticketing system, or email.
+- The agent needs to pass conversational context to another agent or automation.
+
+## YAML Example
+
+**Save Conversation History topic** (create a topic named `Save Conversation History` and paste into the Code editor view):
+
+```yaml
+kind: AdaptiveDialog
+inputs:
+  - kind: AutomaticTaskInput
+    propertyName: ConversationHistory
+    description: "Entire conversation history in the format \"User: question <br /><br /> Agent : response <br /><br /> User: Question <br /><br /> Agent: response\""
+    shouldPromptUser: false
+
+modelDescription: save the conversation history
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent: {}
+  actions:
+    - kind: SendActivity
+      id: sendActivity_gDSbH3
+      activity: "Here is your saved conversation history: {Topic.ConversationHistory}"
+
+inputType:
+  properties:
+    ConversationHistory:
+      displayName: ConversationHistory
+      description: "Entire conversation history in the format \"User: question <br /><br /> Agent : response <br /><br /> User: Question <br /><br /> Agent: response\""
+      type: String
+
+outputType: {}
+```
+
+## Pitfalls
+
+- This transcript is bounded by the orchestrator's context window, so very long conversations may be incomplete.
+- Do not treat the output as a verbatim or compliance-grade audit record.
+- Conversation transcripts may contain PII; capture them only with appropriate consent and retention controls.
+- Often a summary is sufficient and safer than storing the full transcript.
+- When passing conversation history to external tools, email, Dataverse, or MCP servers, treat it as sensitive data.

--- a/patterns/conversation-history-variable.md
+++ b/patterns/conversation-history-variable.md
@@ -14,7 +14,7 @@ This pattern asks the orchestrator to reconstruct the current conversation and p
 
 ### How it works
 
-The orchestrator reads an input variable's `description` to decide what to populate, so the description doubles as an instruction. In this pattern, the description tells the model to fill `ConversationHistory` with the full conversation in a specific format.
+The topic declares an `AutomaticTaskInput` variable named `ConversationHistory` with `shouldPromptUser: false`. The orchestrator reads the variable's `description` field to understand what content and format to fill in. In this pattern, the description instructs the orchestrator to reconstruct the entire conversation and write it into the variable using a specific turn-by-turn format. The topic then uses the populated variable — for example, sending it in a message, storing it, or passing it to a connector.
 
 ### Variations
 

--- a/patterns/deterministic-mcp-calls.md
+++ b/patterns/deterministic-mcp-calls.md
@@ -1,0 +1,97 @@
+---
+name: Deterministic MCP Calls
+description: Improve MCP tool invocation reliability with instruction-based nudges or a dedicated child agent wrapper.
+challenge: Business-critical requests can skip the required MCP tool because MCP actions are generative and cannot be invoked deterministically from topics today.
+status: experimental
+tags: [MCP, MCP-server, tool-invocation, generative-actions, child-agent, deterministic]
+---
+
+## Pattern
+
+MCP tools are exposed to the orchestrator as generative actions, so the platform decides whether to call them. Today there are two important limitations: you cannot force an MCP tool with `/` syntax in instructions, and topics cannot call MCP tools directly. This pattern gives you two practical workarounds.
+
+### Current platform limitations
+
+- **No `/` syntax for MCP tools in instructions** — unlike topics and built-in actions, you cannot prefix an MCP tool name with `/` to force invocation.
+- **No MCP tool nodes in topics** — topics can call connector actions and child agents, but MCP tools are only available to the orchestrator as generative actions.
+
+### Option 1 — Name the tool in agent instructions
+
+The lightest-weight option is to reference the MCP tool explicitly in the agent's instructions and map a user intent to that tool by name.
+
+### Option 2 — Child agent with dedicated intent
+
+For near-deterministic behavior, wrap the MCP tool in a child agent whose only job is to call that tool. The parent routes matching requests to the child through intent routing, and the child's narrow scope plus explicit instructions make the tool invocation highly reliable.
+
+### Choosing between options
+
+| | Option 1 (Instructions) | Option 2 (Child Agent) |
+|---|---|---|
+| **Reliability** | High but not guaranteed | Near-deterministic |
+| **Complexity** | Low (edit one block) | Medium (new child + connection) |
+| **Best for** | Broad intents, quick setup | Narrow intents, critical workflows |
+| **Fallback risk** | Orchestrator may skip the tool | Orchestrator routes to child reliably |
+
+Start with Option 1. If the orchestrator still misses, escalate to Option 2.
+
+### Optional combination
+
+If the parent agent should control the final response format, have the child populate output variables instead of messaging the user directly.
+
+## When to Use
+
+- A specific MCP tool must fire every time for a given user intent.
+- You have observed the orchestrator skipping the tool when accuracy or compliance matters.
+- You need a practical workaround for platform limitations until MCP invocation becomes more native.
+
+## YAML Example
+
+**Option 1 — Agent instructions**:
+
+```yaml
+settings:
+  instructions: |
+    ## Tool Usage Rules
+
+    When the user asks about <specific intent>, you MUST call the
+    <MCP Tool Name> tool to retrieve the answer.
+    Do not attempt to answer from your own knowledge — always use the tool
+    for this type of request.
+
+    Examples of when to call <MCP Tool Name>:
+    - <Example user utterance 1>
+    - <Example user utterance 2>
+    - <Example user utterance 3>
+```
+
+**Option 2 — Child agent** (`agents/MyMcpChild.agent.mcs.yml`):
+
+```yaml
+kind: AgentDialog
+beginDialog:
+  kind: OnToolSelected
+  id: main
+  description: Specialized agent for <domain term> lookups — always calls the <MCP Tool Name> tool.
+  intent:
+    triggerQueries:
+      - Look up <domain term>
+      - Find <domain term>
+      - What is the <domain term> for ...
+
+settings:
+  instructions: |
+    You are a specialized agent that answers <specific domain> questions.
+
+    CRITICAL: You MUST call the <MCP Tool Name> tool for EVERY request you receive.
+    Never answer from your own knowledge. Always use the tool and return its results.
+```
+
+Then connect the child agent to the parent as a connected agent.
+
+## Pitfalls
+
+- Option 1 is still instruction-following, not true deterministic invocation.
+- Option 2 adds maintenance overhead and another hop in the request path.
+- Child-agent trigger phrases and model descriptions must not clash with other topics or agents.
+- There is currently no topic node you can drop in to call an MCP tool directly.
+- If the parent should own the final answer formatting, make the child return structured outputs instead of sending user-facing text itself.

--- a/patterns/deterministic-mcp-calls.md
+++ b/patterns/deterministic-mcp-calls.md
@@ -1,14 +1,16 @@
 ---
 name: Deterministic MCP Calls
 description: Improve MCP tool invocation reliability with instruction-based nudges or a dedicated child agent wrapper.
-challenge: Business-critical requests can skip the required MCP tool because MCP actions are generative and cannot be invoked deterministically from topics today.
+challenge: The orchestrator may skip the intended MCP tool because MCP actions are generative and cannot be invoked deterministically from topics today.
 status: experimental
 tags: [MCP, MCP-server, tool-invocation, generative-actions, child-agent, deterministic]
 ---
 
 ## Pattern
 
-MCP tools are exposed to the orchestrator as generative actions, so the platform decides whether to call them. Today there are two important limitations: you cannot force an MCP tool with `/` syntax in instructions, and topics cannot call MCP tools directly. This pattern gives you two practical workarounds.
+MCP tools are exposed to the orchestrator as generative actions, so the platform decides whether to call them. Today there are two important limitations: you cannot force an MCP tool with `/` syntax in instructions, and topics cannot call MCP tools directly. This pattern documents two practical workarounds for these current platform limitations.
+
+> **Note:** These are workarounds for limitations that may be addressed in future platform updates. Revisit this pattern when MCP tool invocation becomes more natively supported.
 
 ### Current platform limitations
 

--- a/patterns/knowledge-hold-message.md
+++ b/patterns/knowledge-hold-message.md
@@ -1,0 +1,81 @@
+---
+name: Knowledge Hold Message
+description: Send an immediate randomized hold message during knowledge search so users know the agent is working.
+challenge: Knowledge retrieval can leave users staring at a silent screen, causing confusion, duplicate questions, and abandonment.
+status: proven
+tags: [OnKnowledgeRequested, hold-message, latency, knowledge-search, user-experience, Power-Fx]
+---
+
+## Pattern
+
+Not all models and channels support native response streaming, which can significantly improve perceived latency for end users. For knowledge-heavy agents where streaming is unavailable, this pattern bridges the gap by sending an immediate hold message so users know the agent is actively working.
+
+> **For multi-tool or multi-agent orchestration**, where latency comes from chained tool calls rather than knowledge search, see the [Chain of Thought Logging](chain-of-thought-logging.md) pattern instead. This pattern is designed specifically for agents with high-volume knowledge retrieval.
+
+This pattern adds an `OnKnowledgeRequested` topic that sends a quick "please hold" message before the orchestrator finishes knowledge retrieval and summarization. A Power Fx `Table()` stores a bank of short messages, `Rand()` chooses one, and `SendActivity` delivers it immediately.
+
+### How it works
+
+1. A custom `OnKnowledgeRequested` topic fires automatically when the orchestrator decides to search knowledge.
+2. A Power Fx `Table()` of hold messages is built inline, with no connector calls or external storage.
+3. `Rand()` and `Index()` select one row.
+4. `SendActivity` sends the chosen message.
+5. The orchestrator continues with its normal knowledge search and summarization flow.
+
+### Trade-off: two messages per response
+
+This pattern intentionally adds an extra message before the knowledge answer. Users get a hold message plus the final answer, which improves perceived latency but can feel chatty if your stakeholders prefer a quieter bot.
+
+### Variation
+
+If you do not need randomization, you can replace the table and selection logic with one fixed hold message.
+
+## When to Use
+
+- Your agent relies heavily on knowledge search and users experience noticeable wait times.
+- You want a more conversational, human-like experience during knowledge retrieval.
+- Users are abandoning conversations or resending questions during search delays.
+- The model or channel does not support streaming, so the user has no visual cue that work is happening.
+
+## YAML Example
+
+**Randomized hold message topic** (create a new topic and paste into the Code editor view):
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnKnowledgeRequested
+  id: main
+  actions:
+    - kind: SetVariable
+      id: setVariable_hM7xQ2
+      variable: init:Topic.HoldMessages
+      value: "=Table({Value: \"Let me dig into that for you...\"}, {Value: \"One moment while I look that up!\"}, {Value: \"Searching my knowledge base now...\"}, {Value: \"Give me just a sec to find that...\"}, {Value: \"On it! Let me check my sources...\"}, {Value: \"Hang tight, I'm pulling up the details...\"}, {Value: \"Great question! Let me research that...\"}, {Value: \"Looking into that right now...\"}, {Value: \"Let me find the best answer for you...\"}, {Value: \"Just a moment while I search for that information...\"}, {Value: \"I'm on the case! One moment please...\"}, {Value: \"Allow me to look that up for you...\"}, {Value: \"Checking my resources now...\"}, {Value: \"Let me see what I can find...\"}, {Value: \"Searching for the most relevant information...\"}, {Value: \"One sec while I hunt that down...\"}, {Value: \"Let me consult my knowledge sources...\"}, {Value: \"Working on finding that answer for you...\"}, {Value: \"Hold on while I track down those details...\"}, {Value: \"Researching that as we speak...\"}, {Value: \"Let me fetch that information for you...\"}, {Value: \"Give me a moment to pull that together...\"}, {Value: \"Scanning my knowledge base for you...\"}, {Value: \"I'll have that info in just a moment...\"}, {Value: \"Diving into the details now...\"}, {Value: \"Rummaging through my notes for you...\"}, {Value: \"Let me look into that for you right away...\"}, {Value: \"Checking on that now, one moment...\"}, {Value: \"Querying my sources for the best answer...\"}, {Value: \"Let me do a quick search on that...\"}, {Value: \"Pulling up the relevant info now...\"}, {Value: \"Bear with me while I find that...\"}, {Value: \"Sifting through the knowledge base...\"}, {Value: \"Let me round up the details for you...\"}, {Value: \"Looking that up right now, hang on...\"}, {Value: \"Just a sec, I want to give you a solid answer...\"}, {Value: \"Let me see what the docs say about that...\"}, {Value: \"Gathering the relevant information...\"}, {Value: \"Almost there, just searching for the best answer...\"}, {Value: \"On the hunt for that info now...\"})"
+
+    - kind: SetVariable
+      id: setVariable_rP4kN8
+      variable: init:Topic.SelectedMessage
+      value: =Index(Topic.HoldMessages, RoundDown(Rand() * CountRows(Topic.HoldMessages), 0) + 1).Value
+
+    - kind: SendActivity
+      id: sendActivity_wK9mT3
+      activity: "{Topic.SelectedMessage}"
+```
+
+> **Note:** `OnKnowledgeRequested` fires automatically when the orchestrator needs to search. You do not add trigger phrases or a search node; the orchestrator performs the search after this topic completes.
+
+**Static hold message variant**:
+
+```yaml
+- kind: SendActivity
+  id: sendActivity_wK9mT3
+  activity: "One moment while I search for that information..."
+```
+
+## Pitfalls
+
+- This pattern adds an extra user-facing message per knowledge request; confirm that the UX trade-off is acceptable.
+- Do **not** use an AI Builder prompt to generate the hold message, because that adds several seconds of real latency before the knowledge search even starts.
+- Keep the hold message short; the goal is reassurance, not another full response.
+- If you want channel-specific behavior, wrap `SendActivity` in a `ConditionGroup` that checks `System.Activity.ChannelId`.
+

--- a/patterns/knowledge-hold-message.md
+++ b/patterns/knowledge-hold-message.md
@@ -75,7 +75,6 @@ beginDialog:
 ## Pitfalls
 
 - This pattern adds an extra user-facing message per knowledge request; confirm that the UX trade-off is acceptable.
-- Do **not** use an AI Builder prompt to generate the hold message, because that adds several seconds of real latency before the knowledge search even starts.
 - Keep the hold message short; the goal is reassurance, not another full response.
 - If you want channel-specific behavior, wrap `SendActivity` in a `ConditionGroup` that checks `System.Activity.ChannelId`.
 

--- a/patterns/line-breaks-in-messages.md
+++ b/patterns/line-breaks-in-messages.md
@@ -1,0 +1,92 @@
+---
+name: Line Breaks in Messages
+description: Use `<br /><br />` inside message and question nodes to render reliable paragraph spacing across channels.
+challenge: Multi-line bot messages collapse into walls of text because most channels render plain YAML newlines as spaces.
+status: proven
+tags: [formatting, line-breaks, SendActivity, Question, paragraph-spacing, br-tag]
+---
+
+## Pattern
+
+This pattern inserts HTML break tags directly into `SendActivity` and `Question` content so Copilot Studio messages render with visible paragraph spacing in Teams, web chat, and other channels. YAML newlines alone are usually not enough; most channels flatten them into spaces.
+
+### How it works
+
+- `<br />` creates a single line break.
+- `<br /><br />` creates paragraph spacing.
+- The YAML `|-` block scalar keeps the source readable and preserves the literal line layout in the file.
+- Plain YAML newlines without `<br />` are rendered as a single space in most channels.
+
+### Quick reference
+
+| Syntax | Effect |
+|---|---|
+| `<br />` | Single line break |
+| `<br /><br />` | Paragraph spacing (double break) |
+| `|-` (YAML block scalar) | Preserves source newlines for multi-line `activity` / `prompt` |
+| Plain YAML newline (without `<br />`) | Rendered as a space in most channels |
+
+## When to Use
+
+- The agent sends longer messages that benefit from visual separation, such as welcome text, instructions, or summaries.
+- `Question` nodes need a preamble before the actual prompt.
+- Users report that bot responses feel like walls of text.
+- You want consistent paragraph spacing across Teams, web chat, and other channels.
+
+## YAML Example
+
+**Message node**:
+
+```yaml
+- kind: SendActivity
+  id: sendActivity_QVhMj2
+  activity: |-
+    Hello! I'm a cool bot.
+    <br /><br />
+    I'm here to help you!
+```
+
+Renders as two visually separated paragraphs:
+
+> Hello! I'm a cool bot.
+>
+> I'm here to help you!
+
+**Question node with preamble**:
+
+```yaml
+- kind: Question
+  id: question_example
+  alwaysPrompt: true
+  variable: init:Topic.UserChoice
+  prompt: |-
+    I need a few details to get started.
+    <br /><br />
+    Please select one of the options below to continue.
+  entity:
+    kind: ClosedListEntityReference
+    entityId: yourAgentName.entity.YourEntity
+```
+
+**Multi-section message**:
+
+```yaml
+- kind: SendActivity
+  id: sendActivity_multiSection
+  activity: |-
+    Welcome to the HR Support Bot!
+    <br /><br />
+    I can help you with:
+    - Leave requests
+    - Benefits enrollment
+    - Payroll questions
+    <br /><br />
+    Just type your question or select an option below to get started.
+```
+
+## Pitfalls
+
+- Always pair `<br /><br />` with `|-` so the YAML stays readable and the rendered output stays consistent.
+- Do not rely on plain newlines alone; most channels will collapse them into spaces.
+- Apply the same technique to both `SendActivity.activity` and `Question.prompt` so formatting stays consistent across the conversation.
+- Test especially long formatted messages in your target channel to avoid overly tall chat bubbles.

--- a/patterns/rai-error-handling.md
+++ b/patterns/rai-error-handling.md
@@ -1,0 +1,174 @@
+---
+name: RAI Error Handling
+description: Classify Azure OpenAI content-filter errors in OnError and return category-specific user messages with telemetry.
+challenge: Users see a generic failure when content filtering blocks a request, so they get no clear explanation or next step for the specific safety category that fired. Only applies to Azure OpenAI models — does not work with Anthropic or xAI models.
+status: recommended
+tags: [OnError, ContentFiltered, RAI, content-filter, Azure-OpenAI, AI-Builder, OpenAIViolence, OpenAIHate, OpenAISelfHarm, OpenAIJailBreak, OpenAIndirectAttack]
+---
+
+## Pattern
+
+> **Model compatibility:** This pattern only works with **Azure OpenAI models** (GPT-4.1, GPT-5, etc.). The `ContentFiltered` error code and `OpenAI*` subcodes are specific to Azure OpenAI's content safety filters. Anthropic (Claude) and xAI (Grok) models use different safety mechanisms and do not produce these error codes.
+
+This pattern overrides the `OnError` system topic so Azure OpenAI Responsible AI (RAI) content-filter events are handled deliberately instead of falling through to a generic error. Two approaches are available — the primary approach reads the subcode directly from `System.Error.SubCode` (zero latency, no extra components), while the secondary approach uses an AI Builder classifier for cases where additional context-aware classification is needed.
+
+### Azure OpenAI RAI subcodes
+
+All RAI errors arrive as `ContentFiltered`, but `System.Error.SubCode` identifies the exact category:
+
+| Subcode | What It Catches |
+|---|---|
+| `OpenAIViolence` | Violent content, weapons, physical harm |
+| `OpenAIHate` | Hateful or discriminatory content |
+| `OpenAISexual` | Sexually explicit content |
+| `OpenAISelfHarm` | Self-injury or suicide content |
+| `OpenAIJailBreak` | **User** attempts to override system instructions / prompt injection |
+| `OpenAIndirectAttack` | Prompt attacks embedded in **external data** (documents, knowledge sources) |
+
+> **Note:** The subcode is `OpenAIndirectAttack` (not `OpenAIIndirectAttack`) — this matches the Azure OpenAI API spelling exactly. `OpenAIJailBreak` = the user attacks the model; `OpenAIndirectAttack` = a grounded document contains the attack.
+
+### Approach 1 — Direct subcode check (primary, recommended)
+
+Read `System.Error.SubCode` directly in a `ConditionGroup`. No AI Builder model, no extra latency, no additional components — just a switch on the platform-provided subcode.
+
+### Approach 2 — AI Builder classifier (secondary)
+
+Use an AI Builder prompt to classify the user's message into a subcode. This adds latency (~4–6s) and requires manual AI Builder model setup, but can be useful when you need context-aware classification beyond what the platform subcode provides (e.g., distinguishing sub-categories within a single subcode).
+
+### Why a single `ConditionGroup`
+
+Only one subcode should match per error. Putting each subcode in its own sequential `ConditionGroup` node means every node still evaluates even after a match. A single `ConditionGroup` with all branches inside `conditions` stops on first match, gives you an `elseActions` fallback for new categories, and keeps all RAI handling in one maintainable node.
+
+## When to Use
+
+- Your agent handles sensitive topics where generic error messages are insufficient.
+- You need category-specific responses, such as crisis resources for self-harm or security messaging for jailbreak attempts.
+- Administrators need visibility into which RAI categories trigger most often.
+- Your industry requires tailored messaging for content-policy violations.
+
+## YAML Example
+
+### Approach 1 — Direct subcode check (primary)
+
+Paste into the Code editor view of the `OnError` system topic:
+
+```yaml
+kind: AdaptiveDialog
+startBehavior: UseLatestPublishedContentAndCancelOtherTopics
+beginDialog:
+  kind: OnError
+  id: main
+  actions:
+    - kind: SetVariable
+      id: setVariable_timestamp
+      variable: init:Topic.CurrentTime
+      value: =Text(Now(), DateTimeFormat.UTC)
+
+    - kind: ConditionGroup
+      id: conditionGroup_raiSwitch
+      conditions:
+        - id: conditionItem_selfHarm
+          condition: =System.Error.SubCode = "OpenAISelfHarm"
+          actions:
+            - kind: SendActivity
+              id: sendActivity_selfHarm
+              activity: "[PLACEHOLDER] If you or someone you know is in crisis, please contact emergency services or a crisis helpline."
+
+        - id: conditionItem_hate
+          condition: =System.Error.SubCode = "OpenAIHate"
+          actions:
+            - kind: SendActivity
+              id: sendActivity_hate
+              activity: "[PLACEHOLDER] Your message was flagged for hateful or discriminatory content."
+
+        - id: conditionItem_sexual
+          condition: =System.Error.SubCode = "OpenAISexual"
+          actions:
+            - kind: SendActivity
+              id: sendActivity_sexual
+              activity: "[PLACEHOLDER] Your message was flagged for sexually explicit content."
+
+        - id: conditionItem_violence
+          condition: =System.Error.SubCode = "OpenAIViolence"
+          actions:
+            - kind: SendActivity
+              id: sendActivity_violence
+              activity: "[PLACEHOLDER] Your message was flagged for violent content. Please rephrase your request."
+
+        - id: conditionItem_jailbreak
+          condition: =System.Error.SubCode = "OpenAIJailBreak"
+          actions:
+            - kind: SendActivity
+              id: sendActivity_jailbreak
+              activity: "[PLACEHOLDER] Your message was flagged as an attempt to override system instructions."
+
+        - id: conditionItem_indirectAttack
+          condition: =System.Error.SubCode = "OpenAIndirectAttack"
+          actions:
+            - kind: SendActivity
+              id: sendActivity_indirectAttack
+              activity: "[PLACEHOLDER] A prompt injection attack was detected in external data. The request has been blocked."
+
+      elseActions:
+        - kind: SendActivity
+          id: sendActivity_fallback
+          activity: |-
+            An error has occurred.
+            Error code: {System.Error.Code}
+            Error subcode: {System.Error.SubCode}
+            Conversation Id: {System.Conversation.Id}
+            Time (UTC): {Topic.CurrentTime}.
+
+    - kind: LogCustomTelemetryEvent
+      id: logTelemetry_rai
+      eventName: OnErrorLog
+      properties: "={ErrorMessage: System.Error.Message, ErrorCode: System.Error.Code, SubCode: System.Error.SubCode, TimeUTC: Topic.CurrentTime, ConversationId: System.Conversation.Id}"
+
+    - kind: CancelAllDialogs
+      id: cancelAll_rai
+
+inputType: {}
+outputType: {}
+```
+
+### Approach 2 — AI Builder classifier (secondary)
+
+If you need context-aware classification beyond the platform subcode, add an AI Builder prompt between the timestamp and the `ConditionGroup`. Configure the AI Builder model manually in the Copilot Studio UI with input `System.Activity.Text` and output `Topic.ContentFilteringreason`.
+
+```yaml
+    - kind: InvokeAIBuilderModelAction
+      id: invokeAIBuilderModelAction_xxoZmJ
+      input:
+        binding:
+          User_20Message: =System.Activity.Text
+      output:
+        binding:
+          predictionOutput: Topic.ContentFilteringreason
+      aIModelId: <YOUR_AI_BUILDER_MODEL_ID>
+```
+
+Then switch the `ConditionGroup` conditions to check `Topic.ContentFilteringreason.text` instead of `System.Error.SubCode`.
+
+**AI Builder classifier prompt:**
+
+```
+Analyze the following user message and identify which Azure OpenAI Content Filter subcode
+would be triggered. Output **only** the exact subcode — nothing else.
+
+Subcodes: OpenAIViolence, OpenAIHate, OpenAISexual, OpenAISelfHarm,
+          OpenAIJailBreak, OpenAIndirectAttack
+
+OpenAIJailBreak = user tries to manipulate the model.
+OpenAIndirectAttack = external/grounded data contains the attack.
+
+Output only the exact matching subcode. Example: OpenAIViolence
+```
+
+## Pitfalls
+
+- **Use Approach 1 first.** `System.Error.SubCode` is provided by the platform at zero cost and zero latency. Only add the AI Builder classifier (Approach 2) if you need classification beyond what the subcode provides.
+- Replace every `[PLACEHOLDER]` with approved organization-specific text.
+- This pattern does **not** weaken platform RAI filtering; it only changes the post-filter user experience.
+- `elseActions` is important because Azure OpenAI may add new subcodes later.
+- If using Approach 2, `Topic.ContentFilteringreason` must match exactly everywhere (lowercase `r` in `reason`), and the AI Builder model must be configured manually in Copilot Studio.
+- **Azure OpenAI only.** The subcodes (`OpenAIViolence`, `OpenAIHate`, etc.) and the `ContentFiltered` error code are specific to Azure OpenAI. Agents using Anthropic (Claude) or xAI (Grok) models will not trigger these codes and need a different error-handling approach.

--- a/patterns/teams-production-hardening.md
+++ b/patterns/teams-production-hardening.md
@@ -1,0 +1,281 @@
+---
+name: Teams Production Hardening
+description: Apply eight coordinated production patterns for Teams and M365 Copilot agents to handle reinstalls, resets, stale context, and diagnostics.
+challenge: Teams and Microsoft 365 Copilot deployments can suffer from stale sessions, missing onboarding after reinstall, inconsistent context initialization, and unhelpful reset or error experiences.
+status: recommended
+tags: [Teams, Microsoft-Teams, M365-Copilot, production, OnInstallationUpdate, OnInactivity, OnSystemRedirect, OnError, diagnostics, suggested-prompts]
+---
+
+## Pattern
+
+This pattern is a coordinated framework of eight production patterns for Copilot Studio agents deployed to Microsoft Teams and, where applicable, Microsoft 365 Copilot. The patterns are designed to work together: variables set by one pattern are read by others, reset behavior depends on context initialization, and the same diagnostics experience is reused in both reset and error flows.
+
+> Treat this as an end-to-end framework, not a pick-and-mix checklist.
+
+### Framework overview
+
+```text
+                  ┌──────────────────────────────────────────┐
+                  │  User opens agent in Teams / M365 Copilot │
+                  └──────────────────┬───────────────────────┘
+                                     │
+          ┌──────────────────────────┼──────────────────────────┐
+          │                          │                          │
+┌─────────▼─────────┐    ┌───────────▼────────────┐   ┌─────────▼──────────┐
+│ 1. OnInstallation │    │ 4. SetContextVariables │   │ 8. Suggested       │
+│    Update         │    │    (fires if blank)    │   │    prompts (config)│
+│    → ConvStart    │    │    → Global.UserContext│   └────────────────────┘
+└─────────┬─────────┘    └────────────────────────┘
+          │                          ▲
+          ▼                          │
+   ConversationStart ─────────────> reads Global.UserContext
+
+   ┌───────────────────────────────────────────────┐
+   │ 2. OnInactivity (12h) ──► clear vars          │
+   │                           set Global.Inactive │
+   │                                               │
+   │ 3. OnActivity (Inactive=true) ──► notify +    │
+   │                                    "Start over"│
+   └─────────────────────┬─────────────────────────┘
+                         │
+                         ▼
+         ┌───────────────────────────────────┐
+         │ 6. Start Over (Adaptive Card)     │
+         │    Yes  ──► 5. Reset Conversation │
+         │    No   ──► continue              │
+         │    Diagnostics panel inline       │
+         └───────────────┬───────────────────┘
+                         ▼
+         ┌───────────────────────────────────┐
+         │ 5. Reset Conversation             │
+         │    Clear scoped vars + history    │
+         │    Redirect to ConversationStart  │
+         └───────────────────────────────────┘
+
+   ┌───────────────────────────────────────────────┐
+   │ 7. OnError (Adaptive Card)                    │
+   │    Error details + diagnostics + "Start over" │
+   │    LogCustomTelemetryEvent                    │
+   └───────────────────────────────────────────────┘
+```
+
+### Shared variables
+
+| Variable | Set by | Read by | Purpose |
+|---|---|---|---|
+| `Global.InactiveConversation` | Pattern 2 (set true), Pattern 3 (reset false) | Pattern 3 | Signals that the next user message should render the session-expired card |
+| `Global.UserContext` | Pattern 4 | Agent instructions, all topics | Structured user context such as Country and Language that survives resets and works in M365 Copilot |
+| `Topic.Confirm` | Pattern 6 | Pattern 6 branches | Yes/No answer for the restart confirmation flow |
+
+### The eight patterns
+
+1. **Handle app reinstalls** — `OnInstallationUpdate` redirects reinstall events back to `ConversationStart` because reinstalling the Teams app does not fire the normal conversation-start flow.
+2. **Clear stale context after inactivity** — `OnInactivity` clears variables and `ConversationHistory`, marks the conversation inactive, and cancels running dialogs.
+3. **Notify the user after an inactivity reset** — an `OnActivity` message handler checks `Global.InactiveConversation`, resets it, and shows a Hero Card with a **Start over** button.
+4. **Set global context variables cross-channel** — a low-priority `OnActivity` topic initializes `Global.UserContext` when blank so Teams and M365 Copilot behave consistently.
+5. **Rebuild Reset Conversation** — override `OnSystemRedirect` to clear scoped variables plus `ConversationHistory`, then route back to `ConversationStart`.
+6. **Rebuild Start Over with diagnostics** — replace the default prompt with an Adaptive Card question backed by a `YesNo` closed-list entity and an advanced diagnostics panel.
+7. **Rebuild OnError with diagnostics and telemetry** — show actionable error details, reuse the same diagnostics panel from Start Over, log telemetry, and end with `CancelAllDialogs`.
+8. **Configure suggested prompts at the agent level** — define 3 to 4 suggested prompts in agent settings so new users see guidance in both Teams and M365 Copilot.
+
+### Pattern 6 details — Start Over with diagnostics
+
+Replace the default Boolean question with an Adaptive Card question using a closed-list `YesNo` entity. The card should include:
+
+- A confirmation header and explanation.
+- `Yes` and `No` action buttons.
+- A collapsed **Advanced options** panel with troubleshooting actions: `Clear state` (`/debug clearstate`), `Clear history` (`/debug clearhistory`), and `Conversation ID` (`/debug conversationid`).
+- Environment details: `System.Bot.EnvironmentId`, `System.Bot.TenantId`.
+- Agent details: `System.Bot.Name`, `System.Bot.Id`, `System.Bot.SchemaName`.
+- User details: `System.User.Language`, `System.User.Id`.
+- Conversation details: `System.Activity.ChannelId`, `System.Conversation.Id`, `Text(Now(), DateTimeFormat.UTC)`.
+
+Branching logic:
+
+- `Yes` → `BeginDialog` to the Reset Conversation topic.
+- `No` → `SendActivity: "Ok. Let's carry on."` plus `RecognizeIntent` on the user's input to return to normal routing.
+
+Setup steps:
+
+1. Create a closed-list entity `YesNo` with items `Yes` and `No`.
+2. Open the system **Start Over** topic.
+3. Replace the Boolean question node with a `Question` node using `ClosedListEntityReference` to `<agent>.entity.YesNo`, storing the answer in `Topic.Confirm`.
+4. Put the Adaptive Card structure above into that `Question.prompt`.
+5. Add `ConditionGroup` branches for `Yes` and `No`.
+
+### Pattern 7 details — OnError with diagnostics
+
+Override the `OnError` system topic with an Adaptive Card that shows:
+
+- Header: `⚠️ Something went wrong` plus a short apology.
+- Error details for `System.Error.Message`, `System.Error.Code`, `System.Conversation.Id`, and `Text(Now(), DateTimeFormat.UTC)`.
+- The same collapsed **Advanced options** diagnostics panel used in Pattern 6.
+- Troubleshooting buttons: Start over, Clear state, Clear history, Conversation ID.
+
+End the topic with `CancelAllDialogs` so the user returns to a clean state.
+
+> This combines naturally with `rai-error-handling`: handle RAI subcodes first, then let all other errors fall through to the generic diagnostic card.
+
+### Pattern 8 details — Suggested prompts
+
+Configure suggested prompts at the **agent** level, not the topic level:
+
+1. Open agent **Settings**.
+2. Go to **Generative AI → Suggested prompts**.
+3. Add 3 or 4 prompts aligned to the agent's core capabilities.
+4. Save the changes at agent level.
+
+In YAML, this shows up as the `conversationStarters` block in `agent.mcs.yml` or `settings.mcs.yml`.
+
+### Validation checklist
+
+- **Pattern 1** — Uninstall and reinstall the Teams app, then verify the Conversation Start greeting appears.
+- **Pattern 4** — Open the agent in Microsoft 365 Copilot and verify `Global.UserContext` is populated before the first answer.
+- **Pattern 2 + 3** — Let the conversation idle past `durationInSeconds`, send a message, and verify the session-expired Hero Card appears.
+- **Pattern 6** — Trigger Start Over and verify the Adaptive Card includes confirmation plus Advanced options with the correct IDs.
+- **Pattern 5** — Confirm `Yes` in Pattern 6 and verify history clears, Conversation Start reruns, and `Global.UserContext` is repopulated.
+- **Pattern 7** — Force a runtime error and verify the error card shows the message, code, conversation ID, UTC timestamp, and that `OnErrorLog` appears in telemetry.
+- **Pattern 8** — Start a new conversation and verify suggested prompts appear in both Teams and M365 Copilot.
+
+## When to Use
+
+- Your agent is deployed or will be deployed to Microsoft Teams, especially with long-lived conversations.
+- You need consistent behavior across Teams and Microsoft 365 Copilot.
+- Users report stale context, confusing resets, or generic errors with no path forward.
+- Support teams need self-serve diagnostics such as environment, tenant, agent, and conversation identifiers.
+
+## YAML Example
+
+**Pattern 1 — Handle app reinstalls**:
+
+```yaml
+kind: AdaptiveDialog
+startBehavior: UseLatestPublishedContentAndCancelOtherTopics
+beginDialog:
+  kind: OnActivity
+  id: main
+  type: InstallationUpdate
+  actions:
+    - kind: BeginDialog
+      id: Bqmh4L
+      dialog: cat_B2EAgent.topic.ConversationStart
+```
+
+**Pattern 2 — Clear stale context after inactivity**:
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnInactivity
+  id: main
+  condition: =System.Activity.ChannelId = "msteams"
+  durationInSeconds: 43200
+  actions:
+    - kind: ClearAllVariables
+      id: mXHosp
+      variables: ConversationHistory
+    - kind: ClearAllVariables
+      id: Vsemgr
+    - kind: SetVariable
+      id: setVariable_6CUITr
+      variable: Global.InactiveConversation
+      value: true
+    - kind: CancelAllDialogs
+      id: webE3j
+inputType: {}
+outputType: {}
+```
+
+**Pattern 3 — Notify after inactivity-triggered reset**:
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnActivity
+  id: main
+  condition: =Global.InactiveConversation = true
+  type: Message
+  actions:
+    - kind: SetVariable
+      id: setVariable_G6aAbW
+      variable: Global.InactiveConversation
+      value: false
+    - kind: SendActivity
+      id: sendActivity_pgGjvA
+      activity:
+        attachments:
+          - kind: HeroCardTemplate
+            title: Session expired
+            subtitle: New conversation started
+            text: ℹ️ Your previous session ended due to inactivity. Your query is now treated as new. Restart anytime.
+            buttons:
+              - kind: MessageBack
+                title: Start over
+                text: Start over
+inputType: {}
+outputType: {}
+```
+
+**Pattern 4 — Set global context variables cross-channel**:
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnActivity
+  id: main
+  priority: -2
+  condition: =IsBlank(Global.UserContext)
+  type: Message
+  actions:
+    - kind: SetVariable
+      id: setVariable_kRbCMi
+      variable: Global.UserContext
+      value: |-
+        ={
+            Country: "USA",
+            Language: "English"
+        }
+inputType: {}
+outputType: {}
+```
+
+**Pattern 5 — Rebuild Reset Conversation**:
+
+```yaml
+kind: AdaptiveDialog
+startBehavior: UseLatestPublishedContentAndCancelOtherTopics
+beginDialog:
+  kind: OnSystemRedirect
+  id: main
+  actions:
+    - kind: ClearAllVariables
+      id: clearAllVariables_73bTFR
+      variables: ConversationScopedVariables
+    - kind: ClearAllVariables
+      id: SLgE7u
+      variables: ConversationHistory
+    - kind: BeginDialog
+      id: U14iCH
+      dialog: cat_B2EAgent.topic.ConversationStart
+    - kind: CancelAllDialogs
+      id: cancelAllDialogs_12Gt21
+```
+
+**Pattern 7 — Telemetry logging node**:
+
+```yaml
+- kind: LogCustomTelemetryEvent
+  id: 9KwEAn
+  eventName: OnErrorLog
+  properties: "={ErrorMessage: System.Error.Message, ErrorCode: System.Error.Code, TimeUTC: Text(Now(), DateTimeFormat.UTC), ConversationId: System.Conversation.Id}"
+```
+
+Patterns 6 and 8 are configuration and Adaptive Card authoring steps in the source material, not standalone YAML blocks.
+
+## Pitfalls
+
+- Apply the patterns in order; earlier patterns establish variables and reset semantics that later patterns assume.
+- Replace every `cat_B2EAgent.topic.*` dialog reference with your own agent schema prefix from `settings.mcs.yml`.
+- `startBehavior: UseLatestPublishedContentAndCancelOtherTopics` is important on Patterns 1, 5, and 7 so published content wins over stale in-flight dialogs.
+- Pattern 2 is intentionally scoped to Teams via `System.Activity.ChannelId = "msteams"`; remove or adapt that condition if you want the behavior on other channels.
+- Patterns 6 and 7 deliberately duplicate the same Advanced options diagnostics experience so users see a consistent troubleshooting surface.

--- a/patterns/teams-production-hardening.md
+++ b/patterns/teams-production-hardening.md
@@ -12,53 +12,6 @@ This pattern is a coordinated framework of eight production patterns for Copilot
 
 > Treat this as an end-to-end framework, not a pick-and-mix checklist.
 
-### Framework overview
-
-```text
-                  ┌──────────────────────────────────────────┐
-                  │  User opens agent in Teams / M365 Copilot │
-                  └──────────────────┬───────────────────────┘
-                                     │
-          ┌──────────────────────────┼──────────────────────────┐
-          │                          │                          │
-┌─────────▼─────────┐    ┌───────────▼────────────┐   ┌─────────▼──────────┐
-│ 1. OnInstallation │    │ 4. SetContextVariables │   │ 8. Suggested       │
-│    Update         │    │    (fires if blank)    │   │    prompts (config)│
-│    → ConvStart    │    │    → Global.UserContext│   └────────────────────┘
-└─────────┬─────────┘    └────────────────────────┘
-          │                          ▲
-          ▼                          │
-   ConversationStart ─────────────> reads Global.UserContext
-
-   ┌───────────────────────────────────────────────┐
-   │ 2. OnInactivity (12h) ──► clear vars          │
-   │                           set Global.Inactive │
-   │                                               │
-   │ 3. OnActivity (Inactive=true) ──► notify +    │
-   │                                    "Start over"│
-   └─────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-         ┌───────────────────────────────────┐
-         │ 6. Start Over (Adaptive Card)     │
-         │    Yes  ──► 5. Reset Conversation │
-         │    No   ──► continue              │
-         │    Diagnostics panel inline       │
-         └───────────────┬───────────────────┘
-                         ▼
-         ┌───────────────────────────────────┐
-         │ 5. Reset Conversation             │
-         │    Clear scoped vars + history    │
-         │    Redirect to ConversationStart  │
-         └───────────────────────────────────┘
-
-   ┌───────────────────────────────────────────────┐
-   │ 7. OnError (Adaptive Card)                    │
-   │    Error details + diagnostics + "Start over" │
-   │    LogCustomTelemetryEvent                    │
-   └───────────────────────────────────────────────┘
-```
-
 ### Shared variables
 
 | Variable | Set by | Read by | Purpose |

--- a/skills/int-patterns/SKILL.md
+++ b/skills/int-patterns/SKILL.md
@@ -92,9 +92,78 @@ Stops the orchestrator from leaking internal reasoning and tool call metadata to
 - The agent has connector actions that the orchestrator invokes indirectly
 - Responses contain `explanation_of_tool_call` or similar internal metadata
 
+### RAI Error Handling → [rai-error-handling.md](${CLAUDE_SKILL_DIR}/../../patterns/rai-error-handling.md)
+
+Classifies Azure OpenAI content-filter errors by subcode in the OnError topic and returns category-specific user messages with telemetry. Azure OpenAI models only — does not work with Anthropic or xAI models.
+
+**Read this pattern when:**
+- The user needs industry-specific or empathetic error messages for RAI content-filter violations
+- The user wants category-specific handling (e.g., crisis resources for self-harm, security messaging for jailbreak attempts)
+- The user asks about `OnError`, `ContentFiltered`, Azure OpenAI content filters, or RAI subcodes
+
+### Line Breaks in Messages → [line-breaks-in-messages.md](${CLAUDE_SKILL_DIR}/../../patterns/line-breaks-in-messages.md)
+
+Uses `<br /><br />` inside message and question nodes to render reliable paragraph spacing across channels.
+
+**Read this pattern when:**
+- Users report that bot messages feel like walls of text
+- Multi-part questions or welcome messages need visual separation
+- The user asks about line breaks, `<br />`, or formatting in messages or questions
+
+### Knowledge Hold Message → [knowledge-hold-message.md](${CLAUDE_SKILL_DIR}/../../patterns/knowledge-hold-message.md)
+
+Sends a randomized hold message during knowledge search so users know the agent is working.
+
+**Read this pattern when:**
+- The agent has noticeable knowledge-search latency
+- Users are abandoning conversations or resending questions during delays
+- The user asks about `OnKnowledgeRequested`, typing indicators, or hold messages
+
+### Deterministic MCP Calls → [deterministic-mcp-calls.md](${CLAUDE_SKILL_DIR}/../../patterns/deterministic-mcp-calls.md)
+
+Workarounds to improve MCP tool invocation reliability using instruction-based nudges or a dedicated child agent wrapper.
+
+**Read this pattern when:**
+- An MCP tool must fire every time for a specific intent but the orchestrator skips it
+- The user asks about forcing MCP tool invocation or `/` syntax with MCP tools
+- The user needs deterministic tool calls for business-critical workflows
+
+### Chain of Thought Logging → [chain-of-thought-logging.md](${CLAUDE_SKILL_DIR}/../../patterns/chain-of-thought-logging.md)
+
+Sends high-level "Thinking" messages during multi-step orchestration to improve observability and perceived responsiveness.
+
+**Read this pattern when:**
+- The agent uses multiple tools, MCP servers, or child agents that chain together
+- Users experience long silences during multi-step reasoning
+- The user wants a debug or observability trace of orchestrator behavior
+- The user asks about streaming, typing indicators, or progress messages for complex flows
+
+### Conversation History Variable → [conversation-history-variable.md](${CLAUDE_SKILL_DIR}/../../patterns/conversation-history-variable.md)
+
+Captures a best-effort conversation transcript into a variable for escalation, logging, and downstream automation.
+
+**Read this pattern when:**
+- The user needs to capture conversation context for live-agent escalation
+- A downstream tool or connector requires conversation history as input
+- The user wants to log conversations to Dataverse, a ticketing system, or email
+
+### Teams Production Hardening → [teams-production-hardening.md](${CLAUDE_SKILL_DIR}/../../patterns/teams-production-hardening.md)
+
+Eight coordinated production patterns for Teams and M365 Copilot agents covering reinstalls, stale context, resets, diagnostics, and suggested prompts.
+
+**Read this pattern when:**
+- The user is deploying or hardening a Copilot Studio agent on Microsoft Teams
+- Users report stale context after returning to a long-running Teams conversation
+- Context variables work on web chat but not in Microsoft 365 Copilot
+- The user wants richer OnError or Start Over experiences with diagnostic info
+- The user asks about `OnInstallationUpdate`, `OnInactivity`, `OnSystemRedirect`, suggested prompts, or Teams-specific behavior
+
 ## Combining patterns
 
 Multiple patterns can be combined in a single agent. Common combinations:
 - **JIT Glossary + JIT User Context** → merge into a single `conversation-init` OnActivity topic (template at `templates/topics/conversation-init.topic.mcs.yml`)
 - **Date Context + JIT User Context** → both go in agent instructions; date is a Power Fx expression, user context is a global variable reference
 - **Orchestrator Variables + JIT User Context** → classify by category AND personalize by country for precise knowledge routing
+- **RAI Error Handling + Teams Production Hardening** → handle RAI subcodes first in OnError, then fall through to the generic diagnostic card from Pattern 7
+- **Knowledge Hold Message + Chain of Thought Logging** → use hold messages for knowledge-heavy agents and CoT logging for multi-tool agents; both reduce perceived latency but solve different problems
+- **Teams Production Hardening + JIT User Context** → Pattern 4 sets `Global.UserContext` cross-channel; replace hard-coded values with the JIT User Context connector call for real profile data


### PR DESCRIPTION
RAI error handling, line breaks, knowledge hold message, deterministic MCP calls, chain of thought logging, conversation history variable, Teams production hardening

New patterns:
- rai-error-handling (recommended): Azure OpenAI content-filter subcode handling in OnError
- line-breaks-in-messages (proven): <br /> for paragraph spacing in SendActivity/Question
- knowledge-hold-message (proven): Random hold messages during knowledge search
- deterministic-mcp-calls (experimental): Workarounds for forcing MCP tool invocation
- chain-of-thought-logging (recommended): Orchestrator reasoning as Thinking messages
- conversation-history-variable (proven): Capture transcript via AutomaticTaskInput
- teams-production-hardening (recommended): 8-pattern framework for Teams deployment

Updated:
- skills/int-patterns/SKILL.md: Added routing entries and combining patterns guidance