### PR TITLE
Update MCP action metadata

### DIFF
--- a/agents/copilot-studio-advisor.md
+++ b/agents/copilot-studio-advisor.md
@@ -24,10 +24,8 @@ You MUST use the appropriate skill for every task. **NEVER** edit YAML, run scri
 | Look up a schema definition | `/copilot-studio:lookup-schema` |
 | List valid kind values | `/copilot-studio:list-kinds` |
 | List all topics | `/copilot-studio:list-topics` |
-| Edit agent settings or instructions | `/copilot-studio:edit-agent` |
-| Modify trigger phrases | `/copilot-studio:edit-triggers` |
-| Run full test suite (to verify fix) | `/copilot-studio:run-tests` |
-| Send a test message (to verify fix) | `/copilot-studio:chat-with-agent` |
+| Run full test suite | `/copilot-studio:run-tests` |
+| Send a test message | `/copilot-studio:chat-with-agent` |
 
 Always invoke the skill first. Only work manually if no skill matches the task — and even then, you MUST validate with `/copilot-studio:validate` afterward.
 

--- a/agents/copilot-studio-advisor.md
+++ b/agents/copilot-studio-advisor.md
@@ -16,7 +16,7 @@ You are an advisory agent for Copilot Studio. You help users design better agent
 
 ## CRITICAL: Always use skills — never do things manually
 
-You MUST use the appropriate skill for every task. **NEVER** edit YAML, run scripts, or look up schema manually when a skill exists.
+You MUST use the appropriate skill for every task. **NEVER** edit YAML, run scripts, or look up schema manually when a skill exists. Some examples are shown in the below table:
 
 | Task | Skill to invoke |
 |------|----------------|
@@ -26,6 +26,9 @@ You MUST use the appropriate skill for every task. **NEVER** edit YAML, run scri
 | List all topics | `/copilot-studio:list-topics` |
 | Run full test suite | `/copilot-studio:run-tests` |
 | Send a test message | `/copilot-studio:chat-with-agent` |
+| Read common patterns | `/copilot-studio:int-patterns` |
+| Copilot Studio schema and more | `/copilot-studio:int-project-context` |
+| Reference tables for YAML authoring | `/copilot-studio:int-reference` |
 
 Always invoke the skill first. Only work manually if no skill matches the task — and even then, you MUST validate with `/copilot-studio:validate` afterward.
 

--- a/evals/fixtures/agent-with-mcp-action/actions/CustomMCP.mcs.yml
+++ b/evals/fixtures/agent-with-mcp-action/actions/CustomMCP.mcs.yml
@@ -1,10 +1,12 @@
-# Name: Custom MCP Server
-# Custom MCP server with user context
+mcs.metadata:
+  componentName: Custom MCP Server
+  description: Custom MCP server with user context
 kind: TaskDialog
 inputs:
   - kind: ManualTaskInput
     propertyName: userid
     value: =System.User.Email
+
 modelDisplayName: Custom MCP Server
 modelDescription: Custom MCP server for internal tools
 action:
@@ -12,6 +14,7 @@ action:
   connectionReference: cr26e_evalTest.shared_custommcp.def456
   connectionProperties:
     mode: Maker
+
   operationDetails:
     kind: ModelContextProtocolMetadata
     operationId: InvokeMCP

--- a/evals/fixtures/agent-with-mcp-action/actions/SearchDocs.mcs.yml
+++ b/evals/fixtures/agent-with-mcp-action/actions/SearchDocs.mcs.yml
@@ -1,5 +1,6 @@
-# Name: Microsoft Learn Docs MCP Server
-# Searches Microsoft Learn documentation
+mcs.metadata:
+  componentName: Microsoft Learn Docs MCP Server
+  description: Searches Microsoft Learn documentation
 kind: TaskDialog
 modelDisplayName: Microsoft Learn Docs MCP Server
 modelDescription: MCP Server to search Microsoft Learn content
@@ -8,6 +9,7 @@ action:
   connectionReference: cr26e_evalTest.shared_microsoftlearndocsmcpserver.abc123
   connectionProperties:
     mode: Invoker
+
   operationDetails:
     kind: ModelContextProtocolMetadata
     operationId: microsoft_docs_search


### PR DESCRIPTION
## Summary
- Update MCP action fixtures to use `mcs.metadata` for component name and description
- Simplify Copilot Studio advisor tool guidance for test commands

## Validation
- Parsed modified MCP action YAML fixtures and verified required metadata/action fields