### PR TITLE
feat: add Channel-Aware Behavior pattern

### DIFF
--- a/patterns/channel-aware-behavior.md
+++ b/patterns/channel-aware-behavior.md
@@ -1,0 +1,107 @@
+---
+name: Channel-Aware Behavior
+description: Detect the host channel (Teams, M365 Copilot, web chat, Direct Line, etc.) from System.Activity.ChannelId and gate behavior per surface.
+challenge: Some agent capabilities (file upload UX, Adaptive Card variants, links to internal apps, voice prompts) work in one channel but not another. Without channel awareness, the agent offers broken affordances or generic responses regardless of where it's running.
+status: experimental
+tags: [channels, Teams, M365 Copilot, Direct Line, web chat, Activity, ChannelId, conditional, Power Fx]
+---
+
+## Pattern
+
+Read `System.Activity.ChannelId` and stash it (plus any derived booleans you need, like `IsTeamsClient`) into global variables. Branch on those values to gate behavior per surface, change Adaptive Card variants, or shorten responses for embedded clients.
+
+**Critical:** `ChannelId` can be a **compound value** of the form `base:subchannel` — e.g. `msteams:Copilot` when the agent is consumed inside Microsoft 365 Copilot in Teams, or `webchat:Sharepoint` when embedded in SharePoint. A naive equality check (`=Lower(ChannelId) = "msteams"`) misses these compound values. Always use `StartsWith` for the base channel and explicit equality (or `EndsWith(":copilot")`) for the sub-channel.
+
+## When to Use
+
+- A feature is unsupported on a specific channel (e.g. file upload prompts don't render the same in M365 Copilot vs. Teams vs. web chat)
+- You need different Adaptive Card layouts per surface (Teams cards vs. generic web cards)
+- You want to suppress a "join this Teams meeting" link when the user is already in Teams
+- You want to detect M365 Copilot (embedded surface) and shorten responses, drop emojis, or change citation style
+- The agent uses voice and you need different speech-output behavior on `directlinespeech` vs. text channels
+
+## YAML Example
+
+A diagnostic / gate topic that reads the channel and branches:
+
+```yaml
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnRecognizedIntent
+  id: main
+  intent:
+    triggerQueries:
+      - dump activity
+
+  actions:
+    - kind: SetVariable
+      id: setPlatform
+      variable: Global.ClientPlatform
+      value: =System.Activity.ChannelId
+
+    - kind: SetVariable
+      id: setIsTeams
+      variable: Global.IsTeamsClient
+      value: =StartsWith(Lower(System.Activity.ChannelId), "msteams")
+
+    - kind: SendActivity
+      id: showState
+      activity: "Channel: {Global.ClientPlatform} | IsTeams: {Global.IsTeamsClient}"
+
+    - kind: ConditionGroup
+      id: gate
+      conditions:
+        - id: blockOnTeams
+          condition: =Global.IsTeamsClient
+          actions:
+            - kind: SendActivity
+              id: blocked
+              activity: BLOCKED branch reached. This action is not available in Teams.
+
+            - kind: EndDialog
+              id: endTeams
+
+      elseActions:
+        - kind: SendActivity
+          id: allowed
+          activity: ALLOWED branch reached. Continuing in non-Teams channel.
+```
+
+The single change from a naive implementation: `StartsWith(Lower(System.Activity.ChannelId), "msteams")` instead of `Lower(...) = "msteams"`. That one line is the difference between catching every Teams surface and silently breaking inside M365 Copilot in Teams.
+
+**Optional — surface the channel to the orchestrator** (in `settings.mcs.yml`):
+
+```yaml
+instructions: |
+  ## Surface Context
+  The user is interacting via channel: {Global.ClientPlatform}
+  When the channel starts with "msteams", prefer Teams-friendly Adaptive Cards over external hyperlinks.
+```
+
+For this to work, declare `ClientPlatform` as a global variable with `aIVisibility: UseInAIContext`.
+
+## Known Channel IDs
+
+| ChannelId (lowercased) | Surface |
+|---|---|
+| `msteams` | Microsoft Teams (standalone agent) |
+| `msteams:copilot` | Agent consumed inside M365 Copilot in Teams |
+| `m365extensions` | M365 Copilot extension surface |
+| `webchat` | Embedded web chat widget |
+| `webchat:sharepoint` | Agent consumed inside SharePoint |
+| `directline` | Direct Line REST/WebSocket clients |
+| `directlinespeech` | Voice / speech clients |
+| `outlook` | Outlook channel |
+| `omnichannel` | Dynamics 365 Omnichannel handoff |
+| `slack`, `telegram`, `facebook`, `skype`, `sms`, `email`, `telephony` | Third-party / Azure Bot Service channels |
+
+When in doubt, send `System.Activity.ChannelId` back to yourself via `SendActivity` during development to confirm the exact value the surface returns. The `dump activity` trigger above is exactly this debug affordance.
+
+## Pitfalls
+
+- **Compound channel IDs.** `ChannelId` may include a sub-channel separator (`:`). Always use `StartsWith` for base-channel checks, not `=`. The Microsoft Agents SDK docs explicitly list `msteams:Copilot` and `webchat:Sharepoint` as valid values.
+- **Case sensitivity.** `ChannelId` casing isn't guaranteed across surfaces. Always `Lower()` before comparing.
+- **Test pane is not a real channel.** The Copilot Studio test pane reports its own channel value, which won't match production. Validate channel behavior in the actual target channel before shipping.
+- **`aIVisibility: UseInAIContext` is required** on the global variable if you want the orchestrator to reason about it in instructions. Without it, the variable exists but the orchestrator ignores it.
+- **Inline vs. one-shot init.** The example above reads the channel inside the consuming topic. If many topics need to branch on channel, lift the detection into a one-shot `OnActivity` init topic (same shape as `jit-user-context`) so it isn't repeated.
+- **Channel detection is not authorization.** Don't use channel as a security boundary — a determined caller can spoof activities via Direct Line. Gate sensitive operations on the authenticated user identity, not the channel.

--- a/skills/int-patterns/SKILL.md
+++ b/skills/int-patterns/SKILL.md
@@ -92,6 +92,15 @@ Stops the orchestrator from leaking internal reasoning and tool call metadata to
 - The agent has connector actions that the orchestrator invokes indirectly
 - Responses contain `explanation_of_tool_call` or similar internal metadata
 
+### Channel-Aware Behavior → [channel-aware-behavior.md](${CLAUDE_SKILL_DIR}/../../patterns/channel-aware-behavior.md)
+
+Detects the host channel from `System.Activity.ChannelId` and gates behavior per surface (Teams, M365 Copilot, web chat, Direct Line, voice).
+
+**Read this pattern when:**
+- A feature works on one channel but breaks on another (file upload, Adaptive Card variants, hyperlinks)
+- The user asks to detect Teams vs. M365 Copilot vs. web vs. voice
+- A naive `=Lower(ChannelId) = "msteams"` check is silently failing for `msteams:Copilot` or other compound channel IDs
+
 ## Combining patterns
 
 Multiple patterns can be combined in a single agent. Common combinations:


### PR DESCRIPTION
## Summary

Adds a new pattern, **Channel-Aware Behavior**, that captures how to detect the host channel via `System.Activity.ChannelId` and gate agent behavior per surface (Teams, M365 Copilot, web chat, Direct Line, voice, etc.).

The pattern's central correctness point: `ChannelId` can be a **compound** `base:subchannel` value (e.g. `msteams:Copilot`, `webchat: confirmed in the Microsoft Agents SDK docs. A naive `=Lower(ChannelId) = "msteams"` check therefore silently misses real Teams sessions consumed via M365 Copilot. The example uses `StartsWith()`.Sharepoint`) 

## Changes

- `patterns/channel-aware-behavior. new pattern with frontmatter, `## Pattern`, `## When to Use`, `## YAML Example`, a `## Known Channel IDs` reference table, and `## Pitfalls`.md` 
- `skills/int-patterns/SKILL. index entry with "Read this pattern " triggers (placed after Prevent Tool Call Leaks).whenmd` 
- `status: experimental` per CONTRIBUTING guidance for new patterns.

## Motivation

Came out of a real debugging case: an inline channel check that worked in the Copilot Studio test pane and standalone Teams app, then silently fell through to the wrong branch when the same agent was consumed inside M365 Copilot in Teams (`msteams:Copilot`). The repo didn't have an existing pattern covering channel detection, and the compound-ID gotcha isn't obvious from the Power Fx surface.

## Validation

- YAML in the example was sanity-checked against existing patterns (`OnRecognizedIntent`, `SetVariable`, `ConditionGroup`, `EndDialog` shapes match what's in `dynamic-topic-redirect.md` and the templates).
- Channel-ID list cross-referenced with:
  - `Microsoft.Agents.Core.Models.Activity.ChannelId` API docs (notes the `channel:sub_channel` format and gives `msteams:Copilot`, `webchat:Sharepoint` as examples)
  - `Microsoft.BotService botServices/channels` ARM enum (canonical channel name list)
  - Teams platform schema doc (``A2022`, confirming `msteams` for Teams)A2020`

## Out of scope

- No code changes to skills, agents, or  pattern files are pure knowledge per CONTRIBUTING.evals 
- No new tags added to the int-patterns indexer beyond the existing convention.