### PR TITLE
fix: prevent silent drop and wrong-format CSV in eval authoring flow (#170)

### DIFF
--- a/agents/copilot-studio-manage.md
+++ b/agents/copilot-studio-manage.md
@@ -50,3 +50,34 @@ Token caching applies to both flows. After initial login, tokens refresh silentl
 ## Agent Discovery
 
 The agent workspace is auto-detected by finding the subfolder with `.mcs/conn.json`. **NEVER hardcode an agent name or path.** If multiple agents are found, ask which one.
+
+## Warn About Unsupported Component Kinds
+
+The LSP `getLocalChanges` classifier only recognizes a subset of schema-valid kinds as syncable components. As of the current binary, the syncable kinds are:
+
+| Component class | Folder | Notable kinds |
+|---|---|---|
+| `GptComponentMetadata` | root | `agent.mcs.yml` |
+| `BotComponentSettings` | root | `settings.mcs.yml` |
+| `DialogComponent` | `topics/` | `AdaptiveDialog` |
+| `KnowledgeSourceComponent` | `knowledge/` | `KnowledgeSourceComponent` |
+| `ActionComponent` | `actions/` | `TaskDialog`, etc. |
+| `BotVariableComponent` | `variables/` | global variables |
+| Workflows / Child agents | `workflows/`, `agents/` | as listed in templates |
+
+**Other schema-valid kinds (e.g., `EvaluationSet`, `EvaluationData`) are NOT picked up by sync.** They will pass `validate` and produce no errors from `push`, but the files never reach the cloud. This is the most common silent-failure mode for users who hand-author eval YAML.
+
+### Required check after `changes` or before `push`
+
+Before reporting that the workspace is "in sync" or "nothing to push", scan the workspace for files with kinds that are not in the syncable list above:
+
+1. Run `Glob: **/*.eval.mcs.yml` and read the first few bytes of each match.
+2. If any file's `kind:` field is in `{EvaluationSet, EvaluationData}` (or any other non-syncable kind), surface a warning to the user, **even if `localChanges` is empty**:
+
+   > **Warning:** Found `<N>` file(s) using kind `<kind>` that are NOT synced to the cloud by `push`:
+   > - `<file-1>`
+   > - `<file-2>`
+   >
+   > These files will not appear in the Copilot Studio portal. If you intended to create in-portal evaluations, delete these and use `/copilot-studio:create-eval-set` to generate a CSV for upload via Evaluate → New evaluation. See issue [#170](https://github.com/microsoft/skills-for-copilot-studio/issues/170).
+
+3. Do **not** suppress this warning when `changes` returns empty arrays. Silent drops are the actual bug — empty diffs are a symptom, not a confirmation of success.

--- a/agents/copilot-studio-test.md
+++ b/agents/copilot-studio-test.md
@@ -38,6 +38,22 @@ Do not ask the user about authentication state — just run `test-auth` and it h
 
 Run `/copilot-studio:create-eval-set`. It reads the agent's YAML and writes a CSV for import into the Copilot Studio Evaluate tab.
 
+### Do NOT author eval files yourself
+
+When the user asks for "evaluation test sets", "test cases", "evals", or similar — **always delegate to `/copilot-studio:create-eval-set`**. Do not author files directly. In particular:
+
+- **Never write `*.eval.mcs.yml` files** with `kind: EvaluationSet` / `kind: EvaluationData`. These kinds exist in `bot.schema.yaml-authoring.json` and pass `validate`, but they are **not in the LSP sync surface** — `getLocalChanges` ignores them, `push` silently drops them, and they never appear in the Copilot Studio portal. Authoring them wastes the user's time.
+- **Never invent a CSV column schema.** The portal's Evaluate-tab CSV is `question,expectedResponse` (the `Testing method` column is ignored on import — it's set in the UI after upload). This is documented at <https://learn.microsoft.com/microsoft-copilot-studio/analytics-agent-evaluation-create>. The `/copilot-studio:create-eval-set` skill already emits the correct format.
+- **Power CAT Kit-format CSV is a different surface.** If the user explicitly asks for Kit/Dataverse bulk import (not the in-portal Evaluate tab), use `/copilot-studio:run-tests-kit` — but do not silently generate Kit-format files when the user asked for "evaluation test sets" generically. The default is the in-portal Evaluate-tab CSV.
+
+### Conversation (multi-turn) evaluations have no CSV upload
+
+The portal's **Conversation (preview)** data type does **not** accept CSV uploads — only Quick conversation set, Full conversation set, or "Use your test chat" (which captures from the Test pane). If a user wants multi-turn evals, tell them to use the Test pane in the portal or one of the auto-generation buttons. Do not produce a multi-turn CSV.
+
+### When in doubt, consult MS Learn before inventing a schema
+
+If a request needs a file format you are not certain about, search MS Learn first (e.g., via `firecrawl-search` or the `WebSearch` tool). Schema-validity in `bot.schema.yaml-authoring.json` is **not** sufficient evidence that a kind/file is supported by a particular runtime surface — the schema is a superset of what each surface accepts. Always confirm against authoritative docs.
+
 ## How to handle "test this utterance" (point testing)
 
 1. Run `/copilot-studio:detect-mode` to find DirectLine vs M365 mode.

--- a/skills/create-eval-set/SKILL.md
+++ b/skills/create-eval-set/SKILL.md
@@ -14,6 +14,13 @@ agent: copilot-studio-test
 
 Create a test set CSV file that can be imported into Copilot Studio's **Evaluate** tab for in-product agent evaluation.
 
+## Critical rules — do not deviate
+
+1. **Output is a CSV file, not YAML.** Never create `*.eval.mcs.yml` files with `kind: EvaluationSet` or `kind: EvaluationData`. Those kinds exist in `bot.schema.yaml-authoring.json` and pass `validate`, but they are not picked up by the LSP sync surface — `push` silently drops them and they never appear in the portal. See [#170](https://github.com/microsoft/skills-for-copilot-studio/issues/170).
+2. **Columns are exactly `question,expectedResponse`.** Do not add `Testing method`, `Expected keywords`, `Expected topic`, `Conversation ID`, `Turn`, or any other column. The portal rejects files with extra columns (`"This file uses the wrong template"`).
+3. **Only the Single response data type accepts CSV.** The Conversation (preview) data type has no CSV upload path — its only sources are Quick conversation set, Full conversation set, and Use your test chat. Do not produce a "conversation CSV"; instead, tell the user to seed multi-turn evals via the Test pane in the portal.
+4. **Authoritative docs**: <https://learn.microsoft.com/microsoft-copilot-studio/analytics-agent-evaluation-create> (Single response) and <https://learn.microsoft.com/microsoft-copilot-studio/analytics-agent-evaluation-multi-turn> (Conversation). Cite these to the user when reporting completion.
+
 ## Phase 1: Understand the Agent
 
 Read the agent's YAML files to understand what it does:

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -50,3 +50,19 @@ Validate Copilot Studio agent YAML files using the LanguageServerHost binary's f
 
    Summary: X files checked, Y errors, Z warnings
    ```
+
+7. **Flag schema-valid-but-not-syncable kinds.** Schema validity does **not** imply the file will be pushed to the cloud — `validate` checks the schema, but `getLocalChanges` uses a narrower component classifier. After validation passes, if any file's `kind:` is in this list, surface an informational note:
+
+   | Kind | Status | Recommendation |
+   |---|---|---|
+   | `EvaluationSet` | Schema-valid, NOT synced | Use `/copilot-studio:create-eval-set` for portal-compatible CSV. See [#170](https://github.com/microsoft/skills-for-copilot-studio/issues/170). |
+   | `EvaluationData` | Schema-valid, NOT synced | Same as above. |
+
+   Output template:
+
+   ```
+   [INFO] <filename> — kind '<kind>' is schema-valid but is NOT pushed to the cloud by sync.
+          See <recommendation>.
+   ```
+
+   This warning prevents the silent-drop class of bug where validation passes, push reports success, and the user can't figure out why their file never reaches the portal.


### PR DESCRIPTION
Fixes #170.

## Summary

Three coupled documentation-level fixes for the evaluation-authoring path the `copilot-studio:test` sub-agent follows when users ask for *"evaluation test sets"*. The end-to-end failure mode reported in #170 was:

1. Sub-agent generates `*.eval.mcs.yml` files with `kind: EvaluationSet` / `EvaluationData` — schema-valid, but silently dropped by `push` (the LSP `getLocalChanges` classifier doesn't recognize them as syncable components).
2. Sub-agent generates a Kit-format CSV when the user wants the portal Evaluate-tab CSV — the columns are different surfaces, and the portal rejects the wrong format.
3. When asked to regenerate the CSV in the correct format, the sub-agent guessed column headers based on YAML property names instead of consulting MS Learn (where the correct schema is documented).

The `create-eval-set` skill already documents the correct CSV format. The bug is that the test sub-agent didn't reach for it by default — it freelanced.

## Changes

| File | Change |
|---|---|
| `agents/copilot-studio-test.md` | Adds a "Do NOT author eval files yourself" subsection. Explicitly forbids writing `*.eval.mcs.yml` with `EvaluationSet`/`EvaluationData` kinds; explicitly forbids inventing CSV columns; routes "create test set" requests through `/copilot-studio:create-eval-set`; documents that Conversation (preview) has no CSV upload; requires MS Learn consultation before inventing schemas. |
| `agents/copilot-studio-manage.md` | Documents the LSP-syncable component classifications. Adds a required post-`changes`/pre-`push` scan for `*.eval.mcs.yml` files (or any non-syncable kind) and a warning template — surfaced **even when `localChanges` is empty**, because empty diffs are the symptom that hides the silent drop. |
| `skills/create-eval-set/SKILL.md` | Promotes the existing "do not write YAML, do not invent columns" guidance to a top-of-file **Critical rules — do not deviate** block with MS Learn citations. The skill already produced correct output; the new block prevents callers from second-guessing it. |
| `skills/validate/SKILL.md` | Adds an `[INFO]` reporting step that flags schema-valid-but-not-syncable kinds (`EvaluationSet`, `EvaluationData`) at validation time with a pointer to `create-eval-set` and #170. Catches the silent-drop class of bug earlier in the workflow. |

Net diff: **70 insertions across 4 files, 0 deletions**. Pure documentation/instruction strengthening — no script changes, no schema changes, no behavior change for syncable kinds.

## Why these fixes (and not others)

The first-instinct fix is to update the LSP `getLocalChanges` classifier to either (a) sync the eval kinds or (b) emit an error for them. That lives in the pre-built `manage-agent.bundle.js` and the LSP binary, which the contributing guide says not to touch from skills/agents. The next best lever is the sub-agent and skill instructions — which is where the actual freelancing happened. If/when the bundle changes to surface unsupported kinds natively, the doc-level warnings here become redundant but harmless.

The fix is deliberately conservative:

- **No change to `create-eval-set`'s output** — it was already correct (`question,expectedResponse`). The PR just makes its critical rules harder to ignore.
- **No deletion of `EvaluationSet` / `EvaluationData` from the schema** — they're real schema definitions, and there may be future tooling that consumes them. The fix targets the silent-drop class of bug, not the schema kinds themselves.
- **No change to how the test sub-agent runs evals** — only how it *creates* test sets.

## Verification

The user who filed #170 has a portable verification kit at `<workspace>/verification/README.md` with the three reproduction scenarios as separate tests:

1. **YAML eval kinds sync gap** — invoke `copilot-studio:test` with "create evaluation test sets". A fully-fixed sub-agent should NOT emit `*.eval.mcs.yml` files. If it does, `copilot-studio:manage`'s post-change scan should surface a warning. Both surfaces are addressed by this PR.
2. **Test sub-agent CSV format** — the resulting CSV should have exactly two columns: `question,expectedResponse`. This is what `create-eval-set` produces today; this PR ensures the test sub-agent reaches the skill instead of freelancing.
3. **MS Learn consultation** — the test sub-agent's instructions now explicitly require consulting MS Learn before inventing any file format. Verification is via inspection of the sub-agent's response (mentions the docs / cites the URL) rather than a code-level assertion.

A reviewer can spot-check by running the failing flow against the modified agent definitions and confirming the test sub-agent now delegates to `create-eval-set` and never authors `*.eval.mcs.yml` files.

## Branch targeting

Per [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md), feature branches fork from the active release branch. This branch is rebased onto `release/2026-W20`. Happy to retarget to `main` or a different release branch if that's preferred.
