### PR TITLE
Add concise instruction authoring guidance

### DIFF
--- a/agents/copilot-studio-author.md
+++ b/agents/copilot-studio-author.md
@@ -74,6 +74,10 @@ You have access to the pattern library via `int-patterns`. When implementing a p
 
 - Always validate YAML after creation/editing
 - Always verify kind values against the schema before writing them
+- Keep agent instructions proportional to the requested behavior. Do not expand instructions with generic, redundant, or stylistic boilerplate unless the user asks for it or the behavior requires it.
+- Prefer minimal semantic edits: preserve existing instructions when possible, change only the parts needed, and avoid rewriting the whole block unless the user requested a rewrite.
+- Do not add generic rules such as "be helpful", "be clear", "be professional", or "ask clarifying questions" when they are already implied by the existing instructions or template.
+- When creating new instructions, use the shortest instruction block that unambiguously defines the role, scope, grounding or tool rules, fallback or escalation behavior, and output format. Omit any category that is not relevant.
 - When `GenerativeActionsEnabled: true`, use topic inputs/outputs via kind: AutomaticTaskInput (not hardcoded "ask a question" nodes/messages, except if that question is conditional to other events). Example: A "Reservation" topic that always needs the group size -> AutomaticTaskInput. A "Reservation" topic that needs a phone number of a contact person if the group size is greater than 6 -> Ask a question node after the condition. 
 - For grounded answers rely on knowledge sources native lookup. Indeed, when you add a knowledge source, Copilot Studio will already be able to query it, without the need of any topic additional topic with `SearchAndSummarizeContent`. However, in situations where you need explicit configurations (like manipulating the query sent to the RAG engine), use `SearchAndSummarizeContent`; Finally, use `AnswerQuestionWithAI` only for general knowledge not grounded in documents (or rely on the orchestrator istructions without even this node).
 - The agent name is dynamic — users clone their own agent. **NEVER hardcode an agent name or path.** Always auto-discover via `Glob: **/agent.mcs.yml`. If multiple agents found, ask which one.

--- a/agents/copilot-studio-author.md
+++ b/agents/copilot-studio-author.md
@@ -74,10 +74,7 @@ You have access to the pattern library via `int-patterns`. When implementing a p
 
 - Always validate YAML after creation/editing
 - Always verify kind values against the schema before writing them
-- Keep agent instructions proportional to the requested behavior. Do not expand instructions with generic, redundant, or stylistic boilerplate unless the user asks for it or the behavior requires it.
-- Prefer minimal semantic edits: preserve existing instructions when possible, change only the parts needed, and avoid rewriting the whole block unless the user requested a rewrite.
-- Do not add generic rules such as "be helpful", "be clear", "be professional", or "ask clarifying questions" when they are already implied by the existing instructions or template.
-- When creating new instructions, use the shortest instruction block that unambiguously defines the role, scope, grounding or tool rules, fallback or escalation behavior, and output format. Omit any category that is not relevant.
+- Keep instruction edits minimal and semantically dense: preserve existing wording, avoid generic boilerplate, and add only rules that change runtime behavior.
 - When `GenerativeActionsEnabled: true`, use topic inputs/outputs via kind: AutomaticTaskInput (not hardcoded "ask a question" nodes/messages, except if that question is conditional to other events). Example: A "Reservation" topic that always needs the group size -> AutomaticTaskInput. A "Reservation" topic that needs a phone number of a contact person if the group size is greater than 6 -> Ask a question node after the condition. 
 - For grounded answers rely on knowledge sources native lookup. Indeed, when you add a knowledge source, Copilot Studio will already be able to query it, without the need of any topic additional topic with `SearchAndSummarizeContent`. However, in situations where you need explicit configurations (like manipulating the query sent to the RAG engine), use `SearchAndSummarizeContent`; Finally, use `AnswerQuestionWithAI` only for general knowledge not grounded in documents (or rely on the orchestrator istructions without even this node).
 - The agent name is dynamic — users clone their own agent. **NEVER hardcode an agent name or path.** Always auto-discover via `Glob: **/agent.mcs.yml`. If multiple agents found, ask which one.

--- a/skills/edit-agent/SKILL.md
+++ b/skills/edit-agent/SKILL.md
@@ -32,7 +32,15 @@ Modify agent metadata (`agent.mcs.yml`) or configuration (`settings.mcs.yml`).
 
 4. **Read the current file** before making any changes.
 
-5. **Make the requested changes** using the Edit tool.
+5. **When editing `instructions`, keep the change semantically dense**:
+   - Prefer minimal-diff edits over full rewrites.
+   - Preserve user-provided wording unless it is unclear, unsafe, or structurally broken.
+   - Do not add generic behavior rules unless the user specifically requested them.
+   - If the user provides a short instruction, keep it short.
+   - Only expand instructions when there is semantic need: grounding, tool routing, compliance, escalation, scope boundaries, output format, or known platform behavior.
+   - Before saving, remove duplicated rules and merge overlapping bullets.
+
+6. **Make the requested changes** using the Edit tool.
 
 ## Editable Fields in `agent.mcs.yml`
 
@@ -74,8 +82,6 @@ If the user asks to change any of these, warn them.
 instructions: |
   You are a customer support agent for Contoso Ltd.
 
-  Guidelines:
-  - Be professional and empathetic
-  - Always verify the customer's identity first
-  - Escalate billing issues to a human agent
+  Verify the customer's identity before account-specific help.
+  Escalate billing issues to a human agent.
 ```

--- a/skills/edit-agent/SKILL.md
+++ b/skills/edit-agent/SKILL.md
@@ -32,13 +32,7 @@ Modify agent metadata (`agent.mcs.yml`) or configuration (`settings.mcs.yml`).
 
 4. **Read the current file** before making any changes.
 
-5. **When editing `instructions`, keep the change semantically dense**:
-   - Prefer minimal-diff edits over full rewrites.
-   - Preserve user-provided wording unless it is unclear, unsafe, or structurally broken.
-   - Do not add generic behavior rules unless the user specifically requested them.
-   - If the user provides a short instruction, keep it short.
-   - Only expand instructions when there is semantic need: grounding, tool routing, compliance, escalation, scope boundaries, output format, or known platform behavior.
-   - Before saving, remove duplicated rules and merge overlapping bullets.
+5. **For `instructions`, prefer minimal edits**: preserve user wording, avoid full rewrites and generic boilerplate, and add only rules that change runtime behavior.
 
 6. **Make the requested changes** using the Edit tool.
 

--- a/skills/edit-agent/instructions-guide.md
+++ b/skills/edit-agent/instructions-guide.md
@@ -13,20 +13,7 @@ The instructions field directly controls:
 
 ## Keep Instructions Semantically Dense
 
-Good instructions are not necessarily long instructions. Add a directive only when it changes runtime behavior.
-
-Avoid:
-- Restating generic assistant qualities
-- Repeating the same rule in different words
-- Adding broad tone or personality sections unless requested
-- Expanding a short user request into a full policy document
-
-Prefer:
-- One clear role sentence
-- A short scope statement
-- Specific grounding, tool, or use-case rules only when needed
-- A compact fallback or escalation rule if relevant
-- Output formatting rules only when the user or scenario requires them
+Add a directive only when it changes runtime behavior. Prefer one clear role or scope statement plus only required grounding, tool, fallback, escalation, or output-format rules; avoid generic assistant qualities, repeated rules, and broad tone sections unless requested.
 
 ## Writing Knowledge-Aware Instructions
 

--- a/skills/edit-agent/instructions-guide.md
+++ b/skills/edit-agent/instructions-guide.md
@@ -11,6 +11,23 @@ The instructions field directly controls:
 - **Fallback behavior**: what the agent says when no relevant information is found
 - **Scope enforcement**: whether the agent stays on-topic or answers anything
 
+## Keep Instructions Semantically Dense
+
+Good instructions are not necessarily long instructions. Add a directive only when it changes runtime behavior.
+
+Avoid:
+- Restating generic assistant qualities
+- Repeating the same rule in different words
+- Adding broad tone or personality sections unless requested
+- Expanding a short user request into a full policy document
+
+Prefer:
+- One clear role sentence
+- A short scope statement
+- Specific grounding, tool, or use-case rules only when needed
+- A compact fallback or escalation rule if relevant
+- Output formatting rules only when the user or scenario requires them
+
 ## Writing Knowledge-Aware Instructions
 
 Use these directives in `instructions` to shape knowledge behavior:


### PR DESCRIPTION
## Summary
- Add global authoring guidance to keep Copilot Studio agent instructions proportional and semantically dense.
- Tighten the edit-agent skill to prefer minimal-diff instruction edits and avoid generic boilerplate.
- Document concise instruction-writing guidance in the edit-agent instructions guide.

## Validation
- git diff --check