### PR TITLE
fix: quote argument-hint to prevent YAML array parsing in clone-agent and detect-mode

### DIFF
--- a/skills/clone-agent/SKILL.md
+++ b/skills/clone-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 user-invocable: false
 description: Clone a Copilot Studio agent from the cloud. Guides through environment selection, agent selection, and downloads agent YAML files.
-argument-hint: [agent name or environment hint]
+argument-hint: "[agent name or environment hint]"
 allowed-tools: Bash(node *manage-agent.bundle.js *), Read, Glob, Grep
 context: fork
 agent: copilot-studio-manage

--- a/skills/detect-mode/SKILL.md
+++ b/skills/detect-mode/SKILL.md
@@ -1,7 +1,7 @@
 ---
 user-invocable: false
 description: Detect a Copilot Studio agent's authentication mode (DirectLine vs M365) by querying Dataverse. Returns the mode and connection details needed to chat.
-argument-hint: [--agent-dir <path>]
+argument-hint: "[--agent-dir <path>]"
 allowed-tools: Bash(node *chat-with-agent.bundle.js --detect-only *), Read, Glob
 agent: copilot-studio-test
 ---


### PR DESCRIPTION
## Summary

Fixes #176

Two skills failed to load because their `argument-hint` frontmatter used unquoted square brackets, which YAML parses as an **array** instead of a **string**.

## Error

```
The following skills failed to load:
X skills\clone-agent\SKILL.md: argument-hint must be a string
X skills\detect-mode\SKILL.md: argument-hint must be a string
```

## Changes

| File | Before | After |
|------|--------|-------|
| `skills/clone-agent/SKILL.md` | `argument-hint: [agent name or environment hint]` | `argument-hint: "[agent name or environment hint]"` |
| `skills/detect-mode/SKILL.md` | `argument-hint: [--agent-dir <path>]` | `argument-hint: "[--agent-dir <path>]"` |

## Root Cause

YAML interprets `[...]` without quotes as an inline sequence (array). Wrapping the values in double quotes ensures they are treated as strings, which is what the CLI expects.

## Testing

Verified locally ? both skills now load successfully and `/skills` shows `30/30 enabled` with no failures.
