### PR TITLE
Add name field to SKILL.md frontmatter so skills load via npx skills add

### DIFF
--- a/skills/add-action/SKILL.md
+++ b/skills/add-action/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: add-action
 user-invocable: false
 description: Guide users through adding a new connector action to a Copilot Studio agent. Connector actions require UI-based connection setup, so this skill walks users through the Copilot Studio portal steps, then delegates to edit-action for YAML modifications.
 argument-hint: <action description, e.g. "post a Teams message">

--- a/skills/add-adaptive-card/SKILL.md
+++ b/skills/add-adaptive-card/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: add-adaptive-card
 user-invocable: false
 description: Generate and insert an Adaptive Card into a Copilot Studio topic using AdaptiveCardPrompt. Use when the user asks to add an adaptive card, rich card, form card, info card, confirmation card, or interactive card to a topic.
 argument-hint: <card-type> in <topic-name>

--- a/skills/add-generative-answers/SKILL.md
+++ b/skills/add-generative-answers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: add-generative-answers
 user-invocable: false
 description: Add generative answer nodes (SearchAndSummarizeContent or AnswerQuestionWithAI) to a Copilot Studio topic. Use this instead of /add-node when the user asks to add grounded answers, knowledge search, generative answers, or AI-powered responses — these nodes require specific patterns (ConditionGroup follow-up, knowledge source references, autoSend, responseCaptureType) that /add-node does not cover.
 argument-hint: <topic-name or "new">

--- a/skills/add-global-variable/SKILL.md
+++ b/skills/add-global-variable/SKILL.md
@@ -1,5 +1,6 @@
 ---
 user-invocable: false
+name: add-global-variable
 description: Add a global variable to a Copilot Studio agent. Use when the user needs a variable that persists across topics in the same conversation and can optionally be visible to the AI orchestrator.
 argument-hint: <variable name and purpose>
 allowed-tools: Read, Write, Glob, Grep

--- a/skills/add-knowledge/SKILL.md
+++ b/skills/add-knowledge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: add-knowledge
 user-invocable: false
 description: Add a knowledge source (public website or SharePoint) to a Copilot Studio agent. Use when the user asks to add a knowledge source, documentation URL, website, or SharePoint site for the agent to search.
 argument-hint: <url>

--- a/skills/add-node/SKILL.md
+++ b/skills/add-node/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: add-node
 user-invocable: false
 description: Add or modify a node in an existing Copilot Studio topic. Use when the user asks to add a question, message, condition, variable, or other node to a topic. Do NOT use this for generative answers or knowledge search — use /add-generative-answers instead.
 argument-hint: <node-type> to <topic-name>

--- a/skills/add-other-agents/SKILL.md
+++ b/skills/add-other-agents/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: add-other-agents
 user-invocable: false
 description: Add child agents, connected agents, or other multi-agent patterns to a Copilot Studio agent. Use when the user asks to create a sub-agent, child agent, connected agent, or call another agent.
 argument-hint: <agent description>

--- a/skills/analyze-evals/SKILL.md
+++ b/skills/analyze-evals/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: analyze-evals
 user-invocable: false
 description: >
   Analyze exported evaluation results from Copilot Studio's Evaluate tab.

--- a/skills/chat-directline/SKILL.md
+++ b/skills/chat-directline/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: chat-directline
 user-invocable: false
 description: Send a message to a Copilot Studio agent via DirectLine v3. Use for agents with no auth or manual auth. Requires a token endpoint URL or DirectLine secret.
 argument-hint: <utterance>

--- a/skills/chat-sdk/SKILL.md
+++ b/skills/chat-sdk/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: chat-sdk
 user-invocable: false
 description: Send a message to a Copilot Studio agent via the Copilot Studio Client SDK (M365). Use for agents with integrated auth (Entra ID SSO). Requires an App Registration Client ID.
 argument-hint: <utterance>

--- a/skills/chat-with-agent/SKILL.md
+++ b/skills/chat-with-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: chat-with-agent
 user-invocable: false
 description: "DEPRECATED: Use /copilot-studio:detect-mode then /copilot-studio:chat-directline or /copilot-studio:chat-sdk instead."
 argument-hint: <utterance to send>

--- a/skills/clone-agent/SKILL.md
+++ b/skills/clone-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: clone-agent
 user-invocable: false
 description: Clone a Copilot Studio agent from the cloud. Guides through environment selection, agent selection, and downloads agent YAML files.
 argument-hint: [agent name or environment hint]

--- a/skills/create-eval-set/SKILL.md
+++ b/skills/create-eval-set/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: create-eval-set
 user-invocable: false
 description: >
   Create a test set CSV file for import into Copilot Studio's in-product Evaluate tab.

--- a/skills/create-eval/SKILL.md
+++ b/skills/create-eval/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: create-eval
 user-invocable: true
 description: Create plugin development eval scenarios (JSON files with natural prompts and deterministic checks for testing plugin skills). NOT for Copilot Studio in-product evaluation — use /copilot-studio:create-eval-set for that.
 argument-hint: <scenario name>

--- a/skills/detect-mode/SKILL.md
+++ b/skills/detect-mode/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: detect-mode
 user-invocable: false
 description: Detect a Copilot Studio agent's authentication mode (DirectLine vs M365) by querying Dataverse. Returns the mode and connection details needed to chat.
 argument-hint: [--agent-dir <path>]

--- a/skills/directline-chat/SKILL.md
+++ b/skills/directline-chat/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: directline-chat
 user-invocable: false
 description: "DEPRECATED: Use /copilot-studio:chat-with-agent instead — it auto-detects DirectLine vs M365 mode. This skill is kept for backwards compatibility only."
 argument-hint: <utterance to send>

--- a/skills/edit-action/SKILL.md
+++ b/skills/edit-action/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: edit-action
 user-invocable: false
 description: Edit an existing action (TaskDialog) in a Copilot Studio agent. Supports connector actions and MCP server actions. Modify inputs, outputs, descriptions, connection mode, and other properties.
 argument-hint: <what to change, e.g. "add description to SharePoint inputs">

--- a/skills/edit-agent/SKILL.md
+++ b/skills/edit-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: edit-agent
 user-invocable: false
 description: Edit Copilot Studio agent settings, instructions, or configuration. Use when the user asks to change agent instructions, display name, conversation starters, AI settings, or generative actions toggle.
 argument-hint: <what to change>

--- a/skills/edit-triggers/SKILL.md
+++ b/skills/edit-triggers/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: edit-triggers
 user-invocable: false
 description: Modify topic triggers — trigger phrases and model description. Use when the user asks to add, remove, or change trigger phrases, or edit a topic's model description.
 argument-hint: <topic-name>

--- a/skills/list-kinds/SKILL.md
+++ b/skills/list-kinds/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: list-kinds
 user-invocable: false
 description: List all available kind discriminator values from the Copilot Studio YAML schema. Use when the user asks what kinds/types are available.
 argument-hint: <optional-filter-keyword>

--- a/skills/list-topics/SKILL.md
+++ b/skills/list-topics/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: list-topics
 user-invocable: false
 description: List all topics in the Copilot Studio agent with their trigger types, phrases, and action counts. Use when the user wants to see what topics exist.
 allowed-tools: Read, Glob, Grep

--- a/skills/lookup-schema/SKILL.md
+++ b/skills/lookup-schema/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: lookup-schema
 user-invocable: false
 description: Look up Copilot Studio YAML schema definitions. Use when the user asks about schema structure, element properties, or how to use a specific YAML kind.
 argument-hint: <definition-name>

--- a/skills/manage-agent/SKILL.md
+++ b/skills/manage-agent/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: manage-agent
 user-invocable: false
 description: Push/pull Copilot Studio agent content via the VS Code extension's LanguageServerHost LSP binary. Handles authentication (interactive browser login for push/pull, device code flow for chat token), sync push, sync pull, clone, and diff operations.
 argument-hint: <push|pull|clone|changes|validate|publish|auth|list-agents|list-envs>

--- a/skills/new-topic/SKILL.md
+++ b/skills/new-topic/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: new-topic
 user-invocable: false
 description: Create a new Copilot Studio topic YAML file. Use when the user asks to create a new topic, conversation flow, or dialog for their agent.
 argument-hint: <topic description>

--- a/skills/run-eval/SKILL.md
+++ b/skills/run-eval/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: run-eval
 user-invocable: false
 description: >
   Run evaluations against a Copilot Studio agent via the Power Platform Evaluation API.

--- a/skills/run-tests-kit/SKILL.md
+++ b/skills/run-tests-kit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: run-tests-kit
 user-invocable: false
 description: >
   Run a batch test suite via the Copilot Studio Kit (Dataverse API).

--- a/skills/test-auth/SKILL.md
+++ b/skills/test-auth/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: test-auth
 user-invocable: false
 description: >
   Authenticate for Copilot Studio evaluation API and SDK chat. Caches a token

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: validate
 user-invocable: false
 description: Validate Copilot Studio agent YAML files using the LSP binary's full diagnostics (YAML structure, Power Fx, schema, cross-file references). Use when the user asks to check, validate, or verify YAML files.
 argument-hint: <path-to-agent-workspace>


### PR DESCRIPTION
## Summary

Adds a `name` field to the YAML frontmatter of every `SKILL.md` that was missing one (28 skills). Previously only the three `int-*` skills declared `name`.

## Why

The [`skills` CLI](https://www.npmjs.com/package/skills) (skills.sh, `npx skills add`) only discovers a skill when its `SKILL.md` frontmatter contains **both** `name` and `description`. Because 28 skills declared only `description`, running:

```bash
npx skills add microsoft/skills-for-copilot-studio --list
```

found just **3** skills. After this change it finds all **31**.

This matters because `npx skills add` lets you install the same skills into many coding agents at once — not only GitHub Copilot, but simultaneously Claude Code, Codex, Cursor, and 60+ other supported agents. Without a `name` field in each skill, those skills simply cannot be loaded through that command.

## Change

- Added `name: <folder-name>` to the frontmatter of the 28 affected `SKILL.md` files. The value matches each skill's folder name (consistent with the existing `int-*` skills).
- No behavioral/content changes to the skills themselves.

## Verification

`npx skills add . --list` now reports **`Found 31 skills`** (previously 3), and every `name` matches its folder.