### PR TITLE
Scope SessionStart hook to Copilot Studio projects only

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"var r=process.env.CLAUDE_PLUGIN_ROOT;if(r){var f=require('fs'),p=require('path');var t=f.readFileSync(p.join(r,'hooks','system-prompt.md'),'utf8');process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'SessionStart',additionalContext:t}}))}\"",
+            "command": "node -e \"var r=process.env.CLAUDE_PLUGIN_ROOT;if(r){require(require('path').join(r,'hooks','print-prompt.js'))}\"",
             "bash": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/print-prompt.js\"",
             "powershell": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/print-prompt.js\""
           },

--- a/hooks/print-prompt.js
+++ b/hooks/print-prompt.js
@@ -1,6 +1,50 @@
 const path = require('path');
 const fs = require('fs');
 
+// Only inject the Copilot Studio system prompt when this session is actually a
+// Copilot Studio project — i.e. an `agent.mcs.yml` exists in the working
+// directory or a subdirectory. This is the plugin's own definition of a CS
+// project (see system-prompt.md: "already inside a Copilot Studio project ...
+// there is an agent.mcs.yml file in the current directory or any subdirectory").
+//
+// A SessionStart hook runs before any user message, so it cannot read user
+// intent; the project marker is the only reliable signal. Without this gate the
+// hook fires on every session and injects the ~11KB prompt into unrelated work.
+function hasCopilotStudioProject(root, maxDepth, maxDirs) {
+  const skip = new Set([
+    'node_modules', '.git', '.svn', '.hg', 'dist', 'build', 'out',
+    '.next', '.cache', '.turbo', 'coverage', 'vendor', 'target',
+  ]);
+  const stack = [[root, 0]];
+  let visited = 0;
+  while (stack.length) {
+    const [dir, depth] = stack.pop();
+    if (++visited > maxDirs) return false; // bounded — never a long scan
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      if (ent.isFile() && ent.name === 'agent.mcs.yml') return true;
+      if (
+        ent.isDirectory() &&
+        depth < maxDepth &&
+        !skip.has(ent.name) &&
+        !ent.name.startsWith('.')
+      ) {
+        stack.push([path.join(dir, ent.name), depth + 1]);
+      }
+    }
+  }
+  return false;
+}
+
+if (!hasCopilotStudioProject(process.cwd(), 4, 2000)) {
+  process.exit(0); // not a Copilot Studio session — inject nothing
+}
+
 const text = fs.readFileSync(path.join(__dirname, 'system-prompt.md'), 'utf8');
 
 // Copilot CLI (v1.0.11+) injects additionalContext from JSON output.


### PR DESCRIPTION
## Problem

The `SessionStart` hook in `hooks/hooks.json` has no matcher/condition, so `hooks/system-prompt.md` (~11KB of "act as manager, delegate to the Advisor/Author/Manage/Test sub-agents" routing rules) is injected into **every** session — including ones with nothing to do with Copilot Studio. I hit this when the prompt showed up in an unrelated session in a non-CS repository.

### Why it matters

Beyond the constant context overhead, the prompt instructs a strong *"bias toward assuming the request is about Copilot Studio"* and that *"using skills directly is FORBIDDEN"*. In a non-CS session those directives apply unless the model explicitly disregards them.

## Fix

Gate the injection on the plugin's **own** definition of a Copilot Studio project — an `agent.mcs.yml` in the working directory or a subdirectory (exactly what `system-prompt.md` already uses to detect *"already inside a Copilot Studio project"*). When no marker is found, `print-prompt.js` exits without output.

A `SessionStart` hook runs before any user message, so it cannot read user intent; the project marker is the only reliable signal available at that point.

### Changes

- **`hooks/print-prompt.js`** — adds a bounded `hasCopilotStudioProject(cwd, depth 4, ≤2000 dirs)` check (skips `node_modules`/`.git`/build dirs) and `process.exit(0)`s when no marker is present. The existing Copilot-CLI-JSON vs Claude-Code-raw output branch is unchanged.
- **`hooks/hooks.json`** — repoints the inline `command` variant (previously read `system-prompt.md` directly) at the now-gated `print-prompt.js`, so the gate is the single source of truth across the `command`/`bash`/`powershell` variants. `setup.js` is untouched.

### Verification

- No marker in cwd → `print-prompt.js` produces **0 bytes** (nothing injected).
- `agent.mcs.yml` present (incl. nested subdirectory) → full prompt injected as before.
- `hooks.json` parses as valid JSON; `print-prompt.js` passes `node --check`.

### Notes / trade-offs

- This changes behaviour for CS work started in a directory that does **not yet** contain an `agent.mcs.yml` (e.g. cloning a brand-new agent from scratch). `system-prompt.md` already documents the clone-first flow, and users can also mention "Copilot Studio" explicitly; happy to add an env-var/opt-in escape hatch (e.g. `COPILOT_STUDIO_ALWAYS_ON=1`) if you'd prefer one.
- Scan depth (4) and dir cap (2000) are conservative defaults — easy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
