### PR TITLE
Update naming for GHCPh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [GitHub Copilot CLI](https://docs.github.com/en/copilot), and [VS Code](https://code.visualstudio.com/) that enables authoring, testing, and troubleshooting [Microsoft Copilot Studio](https://aka.ms/CopilotStudio) **STANDARD** agents through YAML files — directly from your terminal or editor.
 
-Looking for the plugin for modern/enhanced agents? See the [New Microsoft Copilot Studio Plugin](https://github.com/microsoft/copilot-studio-plugin).
+Looking for the plugin for GitHub Copilot harness agents? See the [New Microsoft Copilot Studio Plugin](https://github.com/microsoft/copilot-studio-plugin).
 
 ## Prerequisites
 


### PR DESCRIPTION
Correct naming from modern/enhanced to GHCPh